### PR TITLE
feat(ui): kanban-style colored cards + status filters for all registries

### DIFF
--- a/frontend/app/campaigns/page.tsx
+++ b/frontend/app/campaigns/page.tsx
@@ -4,9 +4,11 @@ import Link from 'next/link'
 import { Megaphone, Plus, Search, Users, DollarSign, UserPlus, Trash2, Sparkles, ArrowRight } from 'lucide-react'
 import { api } from '@/lib/api'
 import StatusBadge from '@/components/ui/StatusBadge'
+import StatusFilterChips from '@/components/ui/StatusFilterChips'
 import ProgressBar from '@/components/ui/ProgressBar'
 import Modal from '@/components/ui/Modal'
 import EmptyState from '@/components/ui/EmptyState'
+import { CAMPAIGN_STATUS_STYLE, CAMPAIGN_STATUS_ORDER } from '@/lib/chart-colors'
 
 export default function CampaignsPage() {
   const [data, setData] = useState<any>(null)
@@ -34,16 +36,15 @@ export default function CampaignsPage() {
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const params: any = {}
+      const params: any = { limit: 200 }
       if (search) params.search = search
-      if (status) params.status = status
       const [res, s] = await Promise.all([api.getCampaigns(params), stats ? null : api.getCampaignStats()])
       setData(res)
       if (s) setStats(s)
     } finally {
       setLoading(false)
     }
-  }, [search, status, stats])
+  }, [search, stats])
 
   const loadInterests = useCallback(async () => {
     setInterestLoading(true)
@@ -162,25 +163,23 @@ export default function CampaignsPage() {
     }
   }
 
-  const statusColors: Record<string, string> = {
-    ACTIVE: 'border-l-pink-400',
-    COMPLETED: 'border-l-blue-500',
-    PAUSED: 'border-l-amber-500',
-    DRAFT: 'border-l-slate-300',
-    CANCELLED: 'border-l-red-400',
-  }
-
   const candidateVolunteers = useMemo(() => {
     const assignedIds = new Set(assignedVolunteers.map(v => v.volunteer?.id))
     return availableVolunteers.filter(v => !assignedIds.has(v.id))
   }, [availableVolunteers, assignedVolunteers])
 
-  const counts = useMemo(() => ({
-    total: data?.total ?? 0,
-    active: data?.data?.filter((campaign: any) => campaign.status === 'ACTIVE').length ?? 0,
-    completed: data?.data?.filter((campaign: any) => campaign.status === 'COMPLETED').length ?? 0,
-    paused: data?.data?.filter((campaign: any) => campaign.status === 'PAUSED').length ?? 0,
-  }), [data])
+  const countsByStatus = useMemo(() => {
+    const acc: Record<string, number> = { ACTIVE: 0, DRAFT: 0, PAUSED: 0, COMPLETED: 0, CANCELLED: 0 }
+    data?.data?.forEach((c: any) => { if (acc[c.status] !== undefined) acc[c.status] += 1 })
+    return acc
+  }, [data])
+
+  const totalCount = data?.data?.length ?? 0
+
+  const filteredCampaigns = useMemo(() => {
+    if (!status) return data?.data ?? []
+    return (data?.data ?? []).filter((c: any) => c.status === status)
+  }, [data, status])
 
   const fmtBRL = (value: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0 }).format(value)
 
@@ -192,7 +191,7 @@ export default function CampaignsPage() {
           <div>
             <p className="text-xs uppercase tracking-[0.4em] text-muted">Campanhas</p>
             <h1 className="text-3xl font-display font-bold">Arrecadação estratégica</h1>
-            <p className="text-sm text-muted mt-1">{counts.total} campanhas em andamento com objetivo claro.</p>
+            <p className="text-sm text-muted mt-1">{totalCount} campanhas em andamento com objetivo claro.</p>
           </div>
           <div className="flex flex-wrap gap-3">
             <button className="btn-primary" onClick={() => setShowModal(true)}>
@@ -205,88 +204,101 @@ export default function CampaignsPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        {[
-          { label: 'Ativas', value: counts.active },
-          { label: 'Concluídas', value: counts.completed },
-          { label: 'Pausadas', value: counts.paused },
-          { label: 'Total', value: counts.total },
-        ].map(stat => (
-          <div key={stat.label} className="card p-4 transition border border-transparent hover:border-white/30">
-            <p className="text-xs uppercase tracking-[0.3em] text-muted">{stat.label}</p>
-            <p className="text-2xl font-semibold text-white">{stat.value}</p>
+      <div className="card p-4 space-y-4">
+        <div className="flex flex-col md:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search size={18} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              type="search"
+              placeholder="Busque campanhas ou metas"
+              className="input w-full pl-10"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
           </div>
-        ))}
-      </div>
-
-      <div className="card p-4 flex flex-col md:flex-row gap-3">
-        <div className="relative flex-1">
-          <Search size={20} className="absolute left-4 top-1/2 -translate-y-1/2 text-muted" />
-          <input
-            type="search"
-            placeholder="Busque campanhas ou metas"
-            className="input w-full pl-12"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
         </div>
-        <select className="input w-full md:w-1/3" value={status} onChange={e => setStatus(e.target.value)}>
-          <option value="">Todos os status</option>
-          {['ACTIVE', 'COMPLETED', 'PAUSED', 'CANCELLED', 'DRAFT'].map(s => (
-            <option key={s} value={s}>{s}</option>
-          ))}
-        </select>
+        <StatusFilterChips
+          styles={CAMPAIGN_STATUS_STYLE}
+          order={CAMPAIGN_STATUS_ORDER}
+          counts={countsByStatus}
+          total={totalCount}
+          value={status}
+          onChange={setStatus}
+          allLabel="Todas"
+        />
       </div>
 
       {loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {[...Array(6)].map((_, i) => <div key={i} className="card h-48 animate-pulse" />)}
         </div>
-      ) : data?.data?.length === 0 ? (
-        <EmptyState icon={Megaphone} title="Nenhuma campanha encontrada" description="Crie uma nova campanha para engajar voluntários." />
+      ) : filteredCampaigns.length === 0 ? (
+        <EmptyState
+          icon={Megaphone}
+          title={status ? `Nenhuma campanha ${CAMPAIGN_STATUS_STYLE[status]?.label.toLowerCase() ?? ''}` : 'Nenhuma campanha encontrada'}
+          description={status ? 'Tente outro filtro ou crie uma nova campanha.' : 'Crie uma nova campanha para engajar voluntários.'}
+        />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {data?.data?.map((campaign: any) => (
-            <div
-              key={campaign.id}
-              className={`card relative overflow-hidden ${statusColors[campaign.status] ?? 'border-l-slate-200'}`}
-            >
-              <div className="absolute inset-0 gradient-accent opacity-0 hover:opacity-90 transition" />
-              <div className="relative space-y-3">
-                <div className="flex items-center gap-3">
-                  <Megaphone size={18} className="text-muted" />
-                  <h3 className="text-lg font-semibold">{campaign.nome}</h3>
-                </div>
-                <p className="text-sm text-muted line-clamp-2">{campaign.descricao || 'Campanha sem descrição.'}</p>
-                <div className="flex items-center justify-between text-[12px] text-muted">
-                  <span>Status: {campaign.status}</span>
-                  <span>{campaign.voluntariosAtivos ?? 0} voluntários alocados</span>
-                </div>
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between text-[13px]">
-                    <span>Arrecadado</span>
-                    <strong>{fmtBRL(campaign.arrecadado || 0)}</strong>
+          {filteredCampaigns.map((campaign: any) => {
+            const s = CAMPAIGN_STATUS_STYLE[campaign.status] ?? CAMPAIGN_STATUS_STYLE.DRAFT
+            return (
+              <div
+                key={campaign.id}
+                className="card relative overflow-hidden group transition hover:-translate-y-0.5"
+                style={{ borderTop: `4px solid ${s.bar}` }}
+              >
+                <div
+                  className="absolute top-0 right-0 w-24 h-24 rounded-full blur-2xl opacity-40 pointer-events-none"
+                  style={{ backgroundColor: s.bg }}
+                />
+                <div className="relative p-5 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Megaphone size={18} style={{ color: s.bar }} />
+                      <h3 className="text-base font-semibold text-slate-900 truncate">{campaign.nome}</h3>
+                    </div>
+                    <span
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold whitespace-nowrap"
+                      style={{ backgroundColor: s.bg, color: s.text }}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: s.bar }} />
+                      {s.label}
+                    </span>
                   </div>
-                  <div className="flex items-center justify-between text-[13px]">
-                    <span>Meta</span>
-                    <strong>{fmtBRL(campaign.metaArrecadacao || 0)}</strong>
+                  <p className="text-sm text-slate-500 line-clamp-2">{campaign.descricao || 'Campanha sem descrição.'}</p>
+                  <div className="flex items-center justify-between text-[12px] text-slate-500">
+                    <span className="flex items-center gap-1"><Users size={12} /> {campaign.voluntariosAtivos ?? 0} voluntários</span>
+                    {campaign.dataFim && (
+                      <span>Até {new Date(campaign.dataFim).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' })}</span>
+                    )}
                   </div>
-                  <ProgressBar value={campaign.arrecadado || 0} max={campaign.metaArrecadacao || 1} size="sm" />
-                </div>
-                <div className="flex flex-wrap gap-2 mt-3 text-xs">
-                  <button
-                    className="btn-outline flex items-center gap-2 py-1 px-3"
-                    onClick={() => openAssignmentModal(campaign)}
-                  >
-                    <UserPlus size={16} /> Alocar voluntários
-                  </button>
-                  <Link href={`/campaigns/${campaign.id}`} className="flex items-center gap-1 text-accent-light">
-                    Ver campanha <ArrowRight size={14} />
-                  </Link>
+                  <div className="space-y-1.5 pt-1">
+                    <div className="flex items-center justify-between text-[12px] text-slate-600">
+                      <span>Arrecadado</span>
+                      <strong className="text-slate-900">{fmtBRL(campaign.arrecadado || 0)}</strong>
+                    </div>
+                    <div className="flex items-center justify-between text-[12px] text-slate-500">
+                      <span>Meta</span>
+                      <span>{fmtBRL(campaign.metaArrecadacao || 0)}</span>
+                    </div>
+                    <ProgressBar value={campaign.arrecadado || 0} max={campaign.metaArrecadacao || 1} size="sm" />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 pt-3 border-t border-slate-100 text-xs">
+                    <button
+                      className="btn-outline flex items-center gap-2 py-1 px-3 text-xs"
+                      onClick={() => openAssignmentModal(campaign)}
+                    >
+                      <UserPlus size={14} /> Alocar voluntários
+                    </button>
+                    <Link href={`/campaigns/${campaign.id}`} className="flex items-center gap-1 font-semibold" style={{ color: s.bar }}>
+                      Ver campanha <ArrowRight size={14} />
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/frontend/app/donations/page.tsx
+++ b/frontend/app/donations/page.tsx
@@ -2,11 +2,12 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Heart, Plus, Search, DollarSign, Package, TrendingUp } from 'lucide-react'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
+import { clsx } from 'clsx'
 import { api } from '@/lib/api'
 import StatusBadge from '@/components/ui/StatusBadge'
 import Modal from '@/components/ui/Modal'
 import EmptyState from '@/components/ui/EmptyState'
-import { CHART_AXIS, CHART_TOOLTIP_STYLE, DONATION_TYPE_COLOR } from '@/lib/chart-colors'
+import { CHART_AXIS, CHART_TOOLTIP_STYLE, DONATION_TYPE_COLOR, donationTypeColor, statusColor } from '@/lib/chart-colors'
 
 const TIPO_OPTIONS = ['MONETARY', 'FOOD', 'CLOTHING', 'MEDICINE', 'EQUIPMENT', 'SERVICE', 'OTHER']
 const TIPO_LABELS: Record<string, string> = {
@@ -14,11 +15,45 @@ const TIPO_LABELS: Record<string, string> = {
   MEDICINE: 'Medicamentos', EQUIPMENT: 'Equipamentos', SERVICE: 'Serviço', OTHER: 'Outro',
 }
 
+const STATUS_OPTIONS = ['PENDING', 'CONFIRMED', 'CANCELLED', 'REFUNDED']
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: 'Pendente', CONFIRMED: 'Confirmada', CANCELLED: 'Cancelada', REFUNDED: 'Estornada',
+}
+
+function FilterChip({ label, color, active, onClick }: { label: string; color?: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'inline-flex items-center gap-2 px-3 py-1.5 rounded-full border text-xs font-semibold transition',
+        active && !color && 'bg-brand-600 text-white border-brand-600',
+        !active && !color && 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50',
+        !active && color && 'bg-white hover:bg-slate-50',
+      )}
+      style={
+        color
+          ? active
+            ? { backgroundColor: color, color: '#fff', borderColor: color }
+            : { color, borderColor: color + '55' }
+          : undefined
+      }
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ backgroundColor: color ? (active ? '#fff' : color) : (active ? '#fff' : '#94a3b8') }}
+      />
+      {label}
+    </button>
+  )
+}
+
 export default function DonationsPage() {
   const [data, setData] = useState<any>(null)
   const [stats, setStats] = useState<any>(null)
   const [loading, setLoading] = useState(true)
   const [tipo, setTipo] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
   const [page, setPage] = useState(1)
   const [showModal, setShowModal] = useState(false)
   const [form, setForm] = useState({ tipo: 'MONETARY', valor: '', descricao: '', doadorNome: '', doadorEmail: '', campaignId: '' })
@@ -29,11 +64,12 @@ export default function DonationsPage() {
     try {
       const params: any = { page, limit: 15 }
       if (tipo) params.tipo = tipo
+      if (statusFilter) params.status = statusFilter
       const [res, s] = await Promise.all([api.getDonations(params), stats ? null : api.getDonationStats()])
       setData(res)
       if (s) setStats(s)
     } finally { setLoading(false) }
-  }, [tipo, page])
+  }, [tipo, statusFilter, page])
 
   useEffect(() => { load() }, [load])
 
@@ -112,15 +148,41 @@ export default function DonationsPage() {
         </div>
       )}
 
-      <div className="card p-4 flex gap-3">
-        <div className="relative flex-1">
+      <div className="card p-4 space-y-3">
+        <div className="relative">
           <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
           <input className="input pl-9" placeholder="Buscar doações..." />
         </div>
-        <select className="input w-auto min-w-[160px]" value={tipo} onChange={e => setTipo(e.target.value)}>
-          <option value="">Todos os tipos</option>
-          {TIPO_OPTIONS.map(t => <option key={t} value={t}>{TIPO_LABELS[t]}</option>)}
-        </select>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-400 mb-1.5">Tipo</p>
+          <div className="flex flex-wrap gap-2">
+            <FilterChip label="Todos" active={tipo === ''} onClick={() => { setTipo(''); setPage(1) }} />
+            {TIPO_OPTIONS.map(t => (
+              <FilterChip
+                key={t}
+                label={TIPO_LABELS[t]}
+                color={donationTypeColor(t)}
+                active={tipo === t}
+                onClick={() => { setTipo(tipo === t ? '' : t); setPage(1) }}
+              />
+            ))}
+          </div>
+        </div>
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-400 mb-1.5">Status</p>
+          <div className="flex flex-wrap gap-2">
+            <FilterChip label="Todos" active={statusFilter === ''} onClick={() => { setStatusFilter(''); setPage(1) }} />
+            {STATUS_OPTIONS.map(s => (
+              <FilterChip
+                key={s}
+                label={STATUS_LABELS[s]}
+                color={statusColor(s)}
+                active={statusFilter === s}
+                onClick={() => { setStatusFilter(statusFilter === s ? '' : s); setPage(1) }}
+              />
+            ))}
+          </div>
+        </div>
       </div>
 
       {loading ? (
@@ -130,28 +192,51 @@ export default function DonationsPage() {
       ) : data?.data?.length === 0 ? (
         <EmptyState icon={Heart} title="Nenhuma doação encontrada" />
       ) : (
-        <div className="card divide-y divide-slate-50">
-          {data?.data?.map((d: any) => (
-            <div key={d.id} className="flex items-center justify-between px-6 py-4 hover:bg-slate-50/50 transition-colors">
-              <div className="flex items-center gap-4">
-                <div className="w-9 h-9 bg-green-50 rounded-xl flex items-center justify-center">
-                  {d.tipo === 'MONETARY' ? <DollarSign size={16} className="text-green-600" /> : <Package size={16} className="text-blue-600" />}
+        <div className="card divide-y divide-slate-50 overflow-hidden">
+          {data?.data?.map((d: any) => {
+            const tipoCor = donationTypeColor(d.tipo)
+            const statCor = statusColor(d.status)
+            return (
+              <div
+                key={d.id}
+                className="flex items-center justify-between gap-3 px-6 py-4 hover:bg-slate-50/50 transition-colors"
+                style={{ boxShadow: `inset 4px 0 0 ${tipoCor}` }}
+              >
+                <div className="flex items-center gap-4 min-w-0">
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                    style={{ backgroundColor: tipoCor + '22', color: tipoCor }}
+                  >
+                    {d.tipo === 'MONETARY' ? <DollarSign size={18} /> : <Package size={18} />}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-800 truncate">{d.doadorNome || 'Doador Anônimo'}</p>
+                    <p className="text-xs text-slate-400 truncate">
+                      {d.campaign?.nome || 'Sem campanha'} · {new Date(d.createdAt).toLocaleDateString('pt-BR')}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-sm font-semibold text-slate-800">{d.doadorNome || 'Doador Anônimo'}</p>
-                  <p className="text-xs text-slate-400">
-                    {d.campaign?.nome || 'Sem campanha'} · {new Date(d.createdAt).toLocaleDateString('pt-BR')}
-                  </p>
+                <div className="flex items-center gap-2 flex-wrap justify-end">
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold"
+                    style={{ backgroundColor: tipoCor + '1f', color: tipoCor }}
+                  >
+                    <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: tipoCor }} />
+                    {TIPO_LABELS[d.tipo] || d.tipo}
+                  </span>
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold"
+                    style={{ backgroundColor: statCor + '1f', color: statCor }}
+                  >
+                    <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: statCor }} />
+                    {STATUS_LABELS[d.status] || d.status}
+                  </span>
+                  {d.valor ? <p className="font-bold text-slate-900 text-sm whitespace-nowrap">{fmtBRL(d.valor)}</p>
+                    : d.descricao ? <p className="text-xs text-slate-600 max-w-[180px] truncate">{d.descricao}</p> : null}
                 </div>
               </div>
-              <div className="flex items-center gap-3">
-                <StatusBadge status={d.tipo} />
-                <StatusBadge status={d.status} />
-                {d.valor && <p className="font-bold text-slate-900 text-sm">{fmtBRL(d.valor)}</p>}
-                {d.descricao && !d.valor && <p className="text-sm text-slate-600">{d.descricao}</p>}
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -4,8 +4,10 @@ import Link from 'next/link'
 import { Calendar, Plus, MapPin, Users, Clock, UserPlus, Trash2, Sparkles, ArrowRight } from 'lucide-react'
 import { api } from '@/lib/api'
 import StatusBadge from '@/components/ui/StatusBadge'
+import StatusFilterChips from '@/components/ui/StatusFilterChips'
 import Modal from '@/components/ui/Modal'
 import EmptyState from '@/components/ui/EmptyState'
+import { EVENT_STATUS_STYLE, EVENT_STATUS_ORDER } from '@/lib/chart-colors'
 
 export default function EventsPage() {
   const [data, setData] = useState<any>(null)
@@ -25,11 +27,9 @@ export default function EventsPage() {
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const params: any = {}
-      if (status) params.status = status
-      setData(await api.getEvents(params))
+      setData(await api.getEvents({ limit: 200 }))
     } finally { setLoading(false) }
-  }, [status])
+  }, [])
 
   useEffect(() => { load() }, [load])
 
@@ -117,22 +117,20 @@ export default function EventsPage() {
     finally { setSaving(false) }
   }
 
-  const statusColor: Record<string, string> = {
-    SCHEDULED: 'border-t-blue-400',
-    ONGOING: 'border-t-green-500',
-    COMPLETED: 'border-t-slate-400',
-    CANCELLED: 'border-t-red-400',
-  }
-
   const eventCandidateVolunteers = eventVolunteerOptions.filter(vol => !eventAssignedVolunteers.some(av => av.volunteer?.id === vol.id))
 
-  const counts = useMemo(() => ({
-    total: data?.total ?? 0,
-    scheduled: data?.data?.filter((ev: any) => ev.status === 'SCHEDULED').length ?? 0,
-    ongoing: data?.data?.filter((ev: any) => ev.status === 'ONGOING').length ?? 0,
-    completed: data?.data?.filter((ev: any) => ev.status === 'COMPLETED').length ?? 0,
-    cancelled: data?.data?.filter((ev: any) => ev.status === 'CANCELLED').length ?? 0,
-  }), [data])
+  const countsByStatus = useMemo(() => {
+    const acc: Record<string, number> = { SCHEDULED: 0, ONGOING: 0, COMPLETED: 0, CANCELLED: 0 }
+    data?.data?.forEach((ev: any) => { if (acc[ev.status] !== undefined) acc[ev.status] += 1 })
+    return acc
+  }, [data])
+
+  const totalCount = data?.data?.length ?? 0
+
+  const filteredEvents = useMemo(() => {
+    if (!status) return data?.data ?? []
+    return (data?.data ?? []).filter((ev: any) => ev.status === status)
+  }, [data, status])
 
   return (
     <div className="space-y-6">
@@ -155,74 +153,85 @@ export default function EventsPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        {['SCHEDULED', 'ONGOING', 'COMPLETED', 'CANCELLED'].map(statusKey => (
-          <button
-            key={statusKey}
-            className={`card p-4 text-left transition border ${status === statusKey ? 'border-pink-400 bg-[rgba(255,111,181,0.1)]' : 'border-transparent hover:border-white/30'}`}
-            onClick={() => setStatus(status === statusKey ? '' : statusKey)}
-          >
-            <p className="text-[10px] uppercase tracking-[0.4em] text-muted">{statusKey === 'SCHEDULED' ? 'Agendados' : statusKey === 'ONGOING' ? 'Em curso' : statusKey === 'COMPLETED' ? 'Concluídos' : 'Cancelados'}</p>
-            <p className="text-2xl font-semibold mt-2 text-white">{counts[statusKey.toLowerCase()] ?? 0}</p>
-          </button>
-        ))}
+      <div className="card p-4">
+        <StatusFilterChips
+          styles={EVENT_STATUS_STYLE}
+          order={EVENT_STATUS_ORDER}
+          counts={countsByStatus}
+          total={totalCount}
+          value={status}
+          onChange={setStatus}
+          allLabel="Todos"
+        />
       </div>
 
       {loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[...Array(6)].map((_, i) => <div key={i} className="card h-48 animate-pulse" />)}
         </div>
-      ) : data?.data?.length === 0 ? (
-        <EmptyState icon={Calendar} title="Nenhum evento encontrado" description="Crie o primeiro evento da organização." />
+      ) : filteredEvents.length === 0 ? (
+        <EmptyState
+          icon={Calendar}
+          title={status ? `Nenhum evento ${EVENT_STATUS_STYLE[status]?.label.toLowerCase() ?? ''}` : 'Nenhum evento encontrado'}
+          description={status ? 'Tente outro filtro ou crie um novo evento.' : 'Crie o primeiro evento da organização.'}
+        />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {data?.data?.map((ev: any) => (
-            <div key={ev.id} className={`card relative overflow-hidden border-l-4 ${statusColor[ev.status] || 'border-l-slate-200'}`}>
-              <div className="absolute inset-0 gradient-accent opacity-0 hover:opacity-70 transition" />
-              <div className="relative space-y-3">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold">{ev.nome}</h3>
-                  <StatusBadge status={ev.status} />
-                </div>
-                {ev.descricao && <p className="text-sm text-muted line-clamp-2">{ev.descricao}</p>}
-                <div className="space-y-2 text-xs text-muted">
-                  {ev.local && (
-                    <div className="flex items-center gap-2">
-                      <MapPin size={12} />
-                      <span>{ev.local}</span>
+          {filteredEvents.map((ev: any) => {
+            const s = EVENT_STATUS_STYLE[ev.status] ?? EVENT_STATUS_STYLE.SCHEDULED
+            return (
+              <div
+                key={ev.id}
+                className="card relative overflow-hidden group transition hover:-translate-y-0.5"
+                style={{ borderTop: `4px solid ${s.bar}` }}
+              >
+                <div
+                  className="absolute top-0 right-0 w-24 h-24 rounded-full blur-2xl opacity-40 pointer-events-none"
+                  style={{ backgroundColor: s.bg }}
+                />
+                <div className="relative p-5 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Calendar size={18} style={{ color: s.bar }} />
+                      <h3 className="text-base font-semibold text-slate-900 truncate">{ev.nome}</h3>
                     </div>
-                  )}
-                  <div className="flex items-center gap-2">
-                    <Clock size={12} />
-                    <span>{new Date(ev.dataInicio).toLocaleDateString('pt-BR', { day: '2-digit', month: 'long' })}</span>
+                    <span
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold whitespace-nowrap"
+                      style={{ backgroundColor: s.bg, color: s.text }}
+                    >
+                      <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: s.bar }} />
+                      {s.label}
+                    </span>
                   </div>
-                  {ev.capacidade && (
-                    <div className="flex items-center gap-2">
-                      <Users size={12} />
-                      <span>{ev._count?.registrations ?? 0}/{ev.capacidade} inscritos</span>
-                    </div>
-                  )}
-                </div>
-                {ev.campaign && (
-                  <div className="text-xs text-accent-light">
-                    Campanha: {ev.campaign.nome}
+                  {ev.descricao && <p className="text-sm text-slate-500 line-clamp-2">{ev.descricao}</p>}
+                  <div className="space-y-1.5 text-xs text-slate-600">
+                    {ev.local && (
+                      <div className="flex items-center gap-2"><MapPin size={12} className="text-slate-400" /><span>{ev.local}</span></div>
+                    )}
+                    <div className="flex items-center gap-2"><Clock size={12} className="text-slate-400" /><span>{new Date(ev.dataInicio).toLocaleDateString('pt-BR', { day: '2-digit', month: 'long' })}</span></div>
+                    {ev.capacidade && (
+                      <div className="flex items-center gap-2"><Users size={12} className="text-slate-400" /><span>{ev._count?.registrations ?? 0}/{ev.capacidade} inscritos</span></div>
+                    )}
                   </div>
-                )}
-                <div className="flex items-center gap-2 pt-3 border-t border-white/10 text-xs">
-                  <button
-                    type="button"
-                    className="btn-outline text-[11px] flex items-center gap-2"
-                    onClick={() => openEventAssignmentModal(ev)}
-                  >
-                    <UserPlus size={14} /> Voluntários
-                  </button>
-                  <Link href={`/events/${ev.id}`} className="flex items-center gap-1 text-accent-light">
-                    Detalhes <ArrowRight size={14} />
-                  </Link>
+                  {ev.campaign && (
+                    <div className="text-xs" style={{ color: s.bar }}>Campanha: {ev.campaign.nome}</div>
+                  )}
+                  <div className="flex items-center gap-3 pt-3 border-t border-slate-100 text-xs">
+                    <button
+                      type="button"
+                      className="btn-outline text-[11px] flex items-center gap-2 px-3 py-1"
+                      onClick={() => openEventAssignmentModal(ev)}
+                    >
+                      <UserPlus size={14} /> Voluntários
+                    </button>
+                    <Link href={`/events/${ev.id}`} className="flex items-center gap-1 font-semibold" style={{ color: s.bar }}>
+                      Detalhes <ArrowRight size={14} />
+                    </Link>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/frontend/app/finance/page.tsx
+++ b/frontend/app/finance/page.tsx
@@ -15,20 +15,33 @@ import { CHART_AXIS, CHART_TOOLTIP_STYLE, FINANCE_FLOW_COLOR } from '@/lib/chart
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
-const PAY_STATUS_CFG: Record<string, { label: string; icon: any; bg: string; text: string; border: string; dot: string }> = {
-  A_PAGAR:   { label: 'A Pagar',   icon: Clock,        bg: 'bg-blue-50',   text: 'text-blue-700',   border: 'border-blue-200',   dot: 'bg-blue-500' },
-  PAGO:      { label: 'Pago',      icon: CheckCircle2, bg: 'bg-green-50',  text: 'text-green-700',  border: 'border-green-200',  dot: 'bg-green-500' },
-  VENCIDO:   { label: 'Vencido',   icon: AlertTriangle,bg: 'bg-red-50',    text: 'text-red-700',    border: 'border-red-200',    dot: 'bg-red-500' },
-  CANCELADO: { label: 'Cancelado', icon: XCircle,      bg: 'bg-slate-100', text: 'text-slate-500',  border: 'border-slate-200',  dot: 'bg-slate-400' },
-  ESTORNADO: { label: 'Estornado', icon: RotateCcw,    bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200', dot: 'bg-orange-500' },
+type FinanceStatusCfg = {
+  label: string
+  icon: any
+  bg: string
+  text: string
+  border: string
+  dot: string
+  /** strong hex for the row left stripe + active chip fill */
+  stripe: string
+  /** soft hex for the row background tint */
+  tint: string
 }
 
-const REC_STATUS_CFG: Record<string, { label: string; icon: any; bg: string; text: string; border: string; dot: string }> = {
-  A_RECEBER: { label: 'A Receber', icon: Clock,        bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-200', dot: 'bg-indigo-500' },
-  RECEBIDO:  { label: 'Recebido',  icon: CheckCircle2, bg: 'bg-green-50',  text: 'text-green-700',  border: 'border-green-200',  dot: 'bg-green-500' },
-  VENCIDO:   { label: 'Vencido',   icon: AlertTriangle,bg: 'bg-red-50',    text: 'text-red-700',    border: 'border-red-200',    dot: 'bg-red-500' },
-  CANCELADO: { label: 'Cancelado', icon: XCircle,      bg: 'bg-slate-100', text: 'text-slate-500',  border: 'border-slate-200',  dot: 'bg-slate-400' },
-  ESTORNADO: { label: 'Estornado', icon: RotateCcw,    bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200', dot: 'bg-orange-500' },
+const PAY_STATUS_CFG: Record<string, FinanceStatusCfg> = {
+  A_PAGAR:   { label: 'A Pagar',   icon: Clock,        bg: 'bg-blue-50',   text: 'text-blue-700',   border: 'border-blue-200',   dot: 'bg-blue-500',   stripe: '#3b82f6', tint: '#eff6ff' },
+  PAGO:      { label: 'Pago',      icon: CheckCircle2, bg: 'bg-green-50',  text: 'text-green-700',  border: 'border-green-200',  dot: 'bg-green-500',  stripe: '#16a34a', tint: '#f0fdf4' },
+  VENCIDO:   { label: 'Vencido',   icon: AlertTriangle,bg: 'bg-red-50',    text: 'text-red-700',    border: 'border-red-200',    dot: 'bg-red-500',    stripe: '#dc2626', tint: '#fef2f2' },
+  CANCELADO: { label: 'Cancelado', icon: XCircle,      bg: 'bg-slate-100', text: 'text-slate-500',  border: 'border-slate-200',  dot: 'bg-slate-400',  stripe: '#94a3b8', tint: '#f8fafc' },
+  ESTORNADO: { label: 'Estornado', icon: RotateCcw,    bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200', dot: 'bg-orange-500', stripe: '#f97316', tint: '#fff7ed' },
+}
+
+const REC_STATUS_CFG: Record<string, FinanceStatusCfg> = {
+  A_RECEBER: { label: 'A Receber', icon: Clock,        bg: 'bg-indigo-50', text: 'text-indigo-700', border: 'border-indigo-200', dot: 'bg-indigo-500', stripe: '#6366f1', tint: '#eef2ff' },
+  RECEBIDO:  { label: 'Recebido',  icon: CheckCircle2, bg: 'bg-green-50',  text: 'text-green-700',  border: 'border-green-200',  dot: 'bg-green-500',  stripe: '#16a34a', tint: '#f0fdf4' },
+  VENCIDO:   { label: 'Vencido',   icon: AlertTriangle,bg: 'bg-red-50',    text: 'text-red-700',    border: 'border-red-200',    dot: 'bg-red-500',    stripe: '#dc2626', tint: '#fef2f2' },
+  CANCELADO: { label: 'Cancelado', icon: XCircle,      bg: 'bg-slate-100', text: 'text-slate-500',  border: 'border-slate-200',  dot: 'bg-slate-400',  stripe: '#94a3b8', tint: '#f8fafc' },
+  ESTORNADO: { label: 'Estornado', icon: RotateCcw,    bg: 'bg-orange-50', text: 'text-orange-700', border: 'border-orange-200', dot: 'bg-orange-500', stripe: '#f97316', tint: '#fff7ed' },
 }
 
 const PAY_CATS: Record<string, string> = {
@@ -657,17 +670,24 @@ export default function FinancePage() {
             <div className="flex gap-2 flex-wrap">
               {['', 'A_PAGAR', 'VENCIDO', 'PAGO', 'CANCELADO', 'ESTORNADO'].map(s => {
                 const cfg = s ? PAY_STATUS_CFG[s] : null
+                const active = payStatus === s
                 return (
                   <button key={s} onClick={() => { setPayStatus(s); setPage(1) }}
-                    className={clsx('text-xs px-3 py-1.5 rounded-lg font-semibold border transition-all',
-                      payStatus === s
-                        ? (cfg ? clsx(cfg.bg, cfg.text, cfg.border) : 'bg-slate-800 text-white border-slate-800')
-                        : 'bg-white text-slate-500 border-slate-200 hover:bg-slate-50')}>
+                    className={clsx('text-xs px-3 py-1.5 rounded-full font-semibold border transition-all inline-flex items-center gap-1.5',
+                      active && !cfg && 'bg-brand-600 text-white border-brand-600',
+                      !active && 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50')}
+                    style={active && cfg ? { backgroundColor: cfg.stripe, color: '#fff', borderColor: cfg.stripe } : cfg ? { color: cfg.stripe, borderColor: cfg.stripe + '55' } : undefined}>
                     {cfg ? (
-                      <span className="flex items-center gap-1.5">
-                        <span className={clsx('w-1.5 h-1.5 rounded-full', cfg.dot)} />{cfg.label}
-                      </span>
-                    ) : 'Todos'}
+                      <>
+                        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: active ? '#fff' : cfg.stripe }} />
+                        {cfg.label}
+                      </>
+                    ) : (
+                      <>
+                        <span className={clsx('w-1.5 h-1.5 rounded-full', active ? 'bg-white' : 'bg-slate-400')} />
+                        Todos
+                      </>
+                    )}
                   </button>
                 )
               })}
@@ -692,11 +712,13 @@ export default function FinancePage() {
                     ))
                   ) : payables?.data?.length === 0 ? (
                     <tr><td colSpan={8} className="px-4 py-12 text-center text-slate-400">Nenhuma conta a pagar encontrada</td></tr>
-                  ) : payables?.data?.map((p: any) => (
-                    <tr key={p.id} className={clsx('border-b border-slate-50 hover:bg-slate-50/60 transition-colors',
-                      p.status === 'VENCIDO' && 'bg-red-50/30',
-                      p.status === 'PAGO' && 'bg-green-50/20',
-                      ['CANCELADO', 'ESTORNADO'].includes(p.status) && 'opacity-60')}>
+                  ) : payables?.data?.map((p: any) => {
+                    const rowCfg = PAY_STATUS_CFG[p.status]
+                    return (
+                    <tr key={p.id}
+                      className={clsx('border-b border-slate-50 hover:bg-slate-50/60 transition-colors',
+                        ['CANCELADO', 'ESTORNADO'].includes(p.status) && 'opacity-70')}
+                      style={rowCfg ? { boxShadow: `inset 4px 0 0 ${rowCfg.stripe}`, backgroundColor: rowCfg.tint } : undefined}>
                       <td className="px-4 py-3"><StatusPill status={p.status} cfg={PAY_STATUS_CFG} /></td>
                       <td className="px-4 py-3">
                         <p className="text-sm font-semibold text-slate-800">{p.descricao}</p>
@@ -717,7 +739,7 @@ export default function FinancePage() {
                       </td>
                       <td className="px-4 py-3"><PayableActions row={p} onAction={onAction} /></td>
                     </tr>
-                  ))}
+                  )})}
                 </tbody>
               </table>
             </div>
@@ -745,17 +767,24 @@ export default function FinancePage() {
             <div className="flex gap-2 flex-wrap">
               {['', 'A_RECEBER', 'VENCIDO', 'RECEBIDO', 'CANCELADO', 'ESTORNADO'].map(s => {
                 const cfg = s ? REC_STATUS_CFG[s] : null
+                const active = recStatus === s
                 return (
                   <button key={s} onClick={() => { setRecStatus(s); setPage(1) }}
-                    className={clsx('text-xs px-3 py-1.5 rounded-lg font-semibold border transition-all',
-                      recStatus === s
-                        ? (cfg ? clsx(cfg.bg, cfg.text, cfg.border) : 'bg-slate-800 text-white border-slate-800')
-                        : 'bg-white text-slate-500 border-slate-200 hover:bg-slate-50')}>
+                    className={clsx('text-xs px-3 py-1.5 rounded-full font-semibold border transition-all inline-flex items-center gap-1.5',
+                      active && !cfg && 'bg-brand-600 text-white border-brand-600',
+                      !active && 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50')}
+                    style={active && cfg ? { backgroundColor: cfg.stripe, color: '#fff', borderColor: cfg.stripe } : cfg ? { color: cfg.stripe, borderColor: cfg.stripe + '55' } : undefined}>
                     {cfg ? (
-                      <span className="flex items-center gap-1.5">
-                        <span className={clsx('w-1.5 h-1.5 rounded-full', cfg.dot)} />{cfg.label}
-                      </span>
-                    ) : 'Todos'}
+                      <>
+                        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: active ? '#fff' : cfg.stripe }} />
+                        {cfg.label}
+                      </>
+                    ) : (
+                      <>
+                        <span className={clsx('w-1.5 h-1.5 rounded-full', active ? 'bg-white' : 'bg-slate-400')} />
+                        Todos
+                      </>
+                    )}
                   </button>
                 )
               })}
@@ -779,11 +808,13 @@ export default function FinancePage() {
                     ))
                   ) : receivables?.data?.length === 0 ? (
                     <tr><td colSpan={8} className="px-4 py-12 text-center text-slate-400">Nenhuma conta a receber encontrada</td></tr>
-                  ) : receivables?.data?.map((r: any) => (
-                    <tr key={r.id} className={clsx('border-b border-slate-50 hover:bg-slate-50/60 transition-colors',
-                      r.status === 'VENCIDO' && 'bg-red-50/30',
-                      r.status === 'RECEBIDO' && 'bg-green-50/20',
-                      ['CANCELADO', 'ESTORNADO'].includes(r.status) && 'opacity-60')}>
+                  ) : receivables?.data?.map((r: any) => {
+                    const rowCfg = REC_STATUS_CFG[r.status]
+                    return (
+                    <tr key={r.id}
+                      className={clsx('border-b border-slate-50 hover:bg-slate-50/60 transition-colors',
+                        ['CANCELADO', 'ESTORNADO'].includes(r.status) && 'opacity-70')}
+                      style={rowCfg ? { boxShadow: `inset 4px 0 0 ${rowCfg.stripe}`, backgroundColor: rowCfg.tint } : undefined}>
                       <td className="px-4 py-3"><StatusPill status={r.status} cfg={REC_STATUS_CFG} /></td>
                       <td className="px-4 py-3">
                         <p className="text-sm font-semibold text-slate-800">{r.descricao}</p>
@@ -804,7 +835,7 @@ export default function FinancePage() {
                       </td>
                       <td className="px-4 py-3"><ReceivableActions row={r} onAction={onAction} /></td>
                     </tr>
-                  ))}
+                  )})}
                 </tbody>
               </table>
             </div>

--- a/frontend/app/volunteers/page.tsx
+++ b/frontend/app/volunteers/page.tsx
@@ -1,12 +1,11 @@
 'use client'
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Users, Search, Plus, Filter, Star, Clock, Award } from 'lucide-react'
 import { api } from '@/lib/api'
-import StatusBadge from '@/components/ui/StatusBadge'
+import StatusFilterChips from '@/components/ui/StatusFilterChips'
 import Modal from '@/components/ui/Modal'
 import EmptyState from '@/components/ui/EmptyState'
-
-const statusOptions = ['', 'ACTIVE', 'INACTIVE', 'PENDING', 'SUSPENDED']
+import { VOLUNTEER_STATUS_STYLE, VOLUNTEER_STATUS_ORDER } from '@/lib/chart-colors'
 
 export default function VolunteersPage() {
   const [data, setData] = useState<any>(null)
@@ -48,6 +47,13 @@ export default function VolunteersPage() {
 
   const fmt = (n: number) => new Intl.NumberFormat('pt-BR').format(n)
 
+  const statusCounts = useMemo(() => ({
+    ACTIVE: stats?.active ?? 0,
+    PENDING: stats?.pending ?? 0,
+    INACTIVE: stats?.inactive ?? 0,
+    SUSPENDED: stats?.suspended ?? 0,
+  }), [stats])
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -84,8 +90,8 @@ export default function VolunteersPage() {
       )}
 
       {/* Filters */}
-      <div className="card p-4 flex flex-col sm:flex-row gap-3">
-        <div className="relative flex-1">
+      <div className="card p-4 space-y-3">
+        <div className="relative">
           <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
           <input
             className="input pl-9"
@@ -94,10 +100,14 @@ export default function VolunteersPage() {
             onChange={e => { setSearch(e.target.value); setPage(1) }}
           />
         </div>
-        <select className="input w-auto min-w-[160px]" value={status} onChange={e => { setStatus(e.target.value); setPage(1) }}>
-          <option value="">Todos os status</option>
-          {statusOptions.slice(1).map(s => <option key={s} value={s}>{s}</option>)}
-        </select>
+        <StatusFilterChips
+          styles={VOLUNTEER_STATUS_STYLE}
+          order={VOLUNTEER_STATUS_ORDER}
+          counts={statusCounts}
+          total={stats?.total ?? (data?.total ?? 0)}
+          value={status}
+          onChange={(v) => { setStatus(v); setPage(1) }}
+        />
       </div>
 
       {/* Grid */}
@@ -123,43 +133,59 @@ export default function VolunteersPage() {
         <EmptyState icon={Users} title="Nenhum voluntário encontrado" description="Tente ajustar os filtros ou adicione um novo voluntário." />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {data?.data?.map((v: any) => (
-            <div key={v.id} className="card-hover p-5 flex flex-col gap-3">
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-400 to-brand-600 flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
-                    {v.nome[0].toUpperCase()}
+          {data?.data?.map((v: any) => {
+            const s = VOLUNTEER_STATUS_STYLE[v.status] ?? VOLUNTEER_STATUS_STYLE.PENDING
+            return (
+              <div
+                key={v.id}
+                className="card p-5 flex flex-col gap-3 transition hover:-translate-y-0.5"
+                style={{ borderTop: `4px solid ${s.bar}` }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div
+                      className="w-11 h-11 rounded-xl flex items-center justify-center text-white font-bold text-lg flex-shrink-0"
+                      style={{ backgroundColor: s.bar }}
+                    >
+                      {v.nome[0].toUpperCase()}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-semibold text-slate-900 text-sm leading-tight truncate">{v.nome}</p>
+                      <p className="text-slate-400 text-xs mt-1 truncate">{v.profissao || 'Sem profissão'}</p>
+                    </div>
                   </div>
-                  <div className="min-w-0">
-                    <p className="font-semibold text-slate-900 text-sm leading-none truncate">{v.nome}</p>
-                    <p className="text-slate-400 text-xs mt-1 truncate">{v.profissao || 'Sem profissão'}</p>
-                  </div>
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] font-bold whitespace-nowrap"
+                    style={{ backgroundColor: s.bg, color: s.text }}
+                  >
+                    <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: s.bar }} />
+                    {s.label}
+                  </span>
                 </div>
-                <StatusBadge status={v.status} />
-              </div>
 
-              {v.email && <p className="text-xs text-slate-400 truncate">{v.email}</p>}
+                {v.email && <p className="text-xs text-slate-400 truncate">{v.email}</p>}
 
-              <div className="flex items-center gap-3 pt-1 border-t border-slate-50">
-                <div className="flex items-center gap-1.5 text-xs text-amber-600">
-                  <Star size={12} className="fill-amber-400 text-amber-400" />
-                  <span className="font-semibold">{fmt(v.pontos)}</span>
-                  <span className="text-slate-400">pts</span>
-                </div>
-                <div className="flex items-center gap-1.5 text-xs text-blue-600">
-                  <Clock size={12} />
-                  <span className="font-semibold">{v.horasContribuidas}h</span>
-                </div>
-                {v.badges?.length > 0 && (
-                  <div className="flex items-center gap-1 ml-auto">
-                    {v.badges.slice(0, 3).map((b: any) => (
-                      <span key={b.id} className="text-sm" title={b.badge.nome}>{b.badge.icone}</span>
-                    ))}
+                <div className="flex items-center gap-3 pt-2 border-t border-slate-100">
+                  <div className="flex items-center gap-1.5 text-xs text-amber-600">
+                    <Star size={12} className="fill-amber-400 text-amber-400" />
+                    <span className="font-semibold">{fmt(v.pontos)}</span>
+                    <span className="text-slate-400">pts</span>
                   </div>
-                )}
+                  <div className="flex items-center gap-1.5 text-xs text-blue-600">
+                    <Clock size={12} />
+                    <span className="font-semibold">{v.horasContribuidas}h</span>
+                  </div>
+                  {v.badges?.length > 0 && (
+                    <div className="flex items-center gap-1 ml-auto">
+                      {v.badges.slice(0, 3).map((b: any) => (
+                        <span key={b.id} className="text-sm" title={b.badge.nome}>{b.badge.icone}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
 

--- a/frontend/components/ui/StatusFilterChips.tsx
+++ b/frontend/components/ui/StatusFilterChips.tsx
@@ -1,0 +1,77 @@
+'use client'
+import { clsx } from 'clsx'
+import type { StatusStyle } from '@/lib/chart-colors'
+
+interface Props {
+  styles: Record<string, StatusStyle>
+  order: readonly string[]
+  counts: Record<string, number>
+  total: number
+  value: string
+  onChange: (next: string) => void
+  allLabel?: string
+}
+
+/**
+ * Kanban-style filter chips. "All" chip resets the filter; each status
+ * chip shows a colored dot and the count. Active chip fills with the
+ * status color so the user instantly sees what is selected.
+ */
+export default function StatusFilterChips({
+  styles,
+  order,
+  counts,
+  total,
+  value,
+  onChange,
+  allLabel = 'Todas',
+}: Props) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onChange('')}
+        className={clsx(
+          'inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full border text-xs font-semibold transition',
+          value === ''
+            ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
+            : 'bg-white text-slate-700 border-slate-200 hover:border-brand-300 hover:text-brand-700',
+        )}
+      >
+        <span className={clsx('w-1.5 h-1.5 rounded-full', value === '' ? 'bg-white' : 'bg-slate-400')} />
+        {allLabel}
+        <span className={clsx('text-[11px] font-bold', value === '' ? 'text-white/90' : 'text-slate-500')}>{total}</span>
+      </button>
+      {order.map(key => {
+        const s = styles[key]
+        if (!s) return null
+        const active = value === key
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(active ? '' : key)}
+            className={clsx(
+              'inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full border text-xs font-semibold transition',
+              !active && 'bg-white hover:bg-slate-50',
+            )}
+            style={
+              active
+                ? { backgroundColor: s.bar, color: '#fff', borderColor: s.bar }
+                : { color: s.text, borderColor: s.bar + '55' }
+            }
+          >
+            <span
+              className="w-1.5 h-1.5 rounded-full"
+              style={{ backgroundColor: active ? '#fff' : s.bar }}
+            />
+            {s.label}
+            <span className={clsx('text-[11px] font-bold', active ? 'text-white/90' : 'text-slate-500')}>
+              {counts[key] ?? 0}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/lib/chart-colors.ts
+++ b/frontend/lib/chart-colors.ts
@@ -71,3 +71,45 @@ export function donationTypeColor(tipo: string | undefined | null, fallback = '#
   if (!tipo) return fallback
   return DONATION_TYPE_COLOR[tipo.toUpperCase()] ?? fallback
 }
+
+/**
+ * Kanban-style palette used by campaign/event cards and status filter chips.
+ * Each status has:
+ *  - label: pt-BR display name
+ *  - bar: strong color for the top stripe / dot / active chip
+ *  - bg: soft tint for card backdrop and idle chip background
+ *  - text: readable text color on the tint
+ */
+export interface StatusStyle {
+  label: string
+  bar: string
+  bg: string
+  text: string
+}
+
+export const CAMPAIGN_STATUS_STYLE: Record<string, StatusStyle> = {
+  DRAFT:     { label: 'Rascunho',  bar: '#94a3b8', bg: '#f1f5f9', text: '#334155' },
+  ACTIVE:    { label: 'Ativa',     bar: '#16a34a', bg: '#ecfdf5', text: '#166534' },
+  PAUSED:    { label: 'Pausada',   bar: '#f59e0b', bg: '#fef3c7', text: '#92400e' },
+  COMPLETED: { label: 'Concluída', bar: '#22518a', bg: '#dbeafe', text: '#1e3a8a' },
+  CANCELLED: { label: 'Cancelada', bar: '#dc2626', bg: '#fee2e2', text: '#991b1b' },
+}
+
+export const EVENT_STATUS_STYLE: Record<string, StatusStyle> = {
+  SCHEDULED: { label: 'Agendado',  bar: '#3b82f6', bg: '#dbeafe', text: '#1e40af' },
+  ONGOING:   { label: 'Em curso',  bar: '#16a34a', bg: '#dcfce7', text: '#166534' },
+  COMPLETED: { label: 'Concluído', bar: '#22518a', bg: '#eff6ff', text: '#1e3a8a' },
+  CANCELLED: { label: 'Cancelado', bar: '#dc2626', bg: '#fee2e2', text: '#991b1b' },
+}
+
+export const CAMPAIGN_STATUS_ORDER = ['ACTIVE', 'DRAFT', 'PAUSED', 'COMPLETED', 'CANCELLED'] as const
+export const EVENT_STATUS_ORDER = ['SCHEDULED', 'ONGOING', 'COMPLETED', 'CANCELLED'] as const
+
+export const VOLUNTEER_STATUS_STYLE: Record<string, StatusStyle> = {
+  ACTIVE:    { label: 'Ativo',    bar: '#16a34a', bg: '#ecfdf5', text: '#166534' },
+  PENDING:   { label: 'Pendente', bar: '#f59e0b', bg: '#fef3c7', text: '#92400e' },
+  INACTIVE:  { label: 'Inativo',  bar: '#64748b', bg: '#f1f5f9', text: '#334155' },
+  SUSPENDED: { label: 'Suspenso', bar: '#dc2626', bg: '#fee2e2', text: '#991b1b' },
+}
+
+export const VOLUNTEER_STATUS_ORDER = ['ACTIVE', 'PENDING', 'INACTIVE', 'SUSPENDED'] as const


### PR DESCRIPTION
## Summary

Faz com que todas as telas de cadastro/listagem fiquem **visualmente distintas por status** e com **filtros reativos por chip**.

### Páginas atualizadas

| Página | Antes | Agora |
|---|---|---|
| `/campaigns` | dropdown de status + card cinza uniforme | chips de status (Ativa/Rascunho/Pausada/Concluída/Cancelada) com contagem + cards com top-border 4px colorido + badge de status |
| `/events` | 4 cards-métrica clicáveis (confusos) + card com `border-l` fina | chips reativos com contagem + cards com top-border colorido (Agendado/Em curso/Concluído/Cancelado) |
| `/finance` (a pagar / a receber) | chip ativo só muda texto + row com bg quase imperceptível | chip ativo com fill colorido + **linha com stripe lateral 4px + tint de fundo por status** (A Pagar azul, Pago verde, Vencido vermelho, Cancelado cinza, Estornado laranja) |
| `/donations` | dropdown único + lista sem cor | chips duplos **Tipo + Status** + linhas com stripe lateral por tipo + dois badges (tipo em `donationTypeColor`, status em `statusColor`) |
| `/volunteers` | dropdown de status + avatar navy | chips reativos com contagem (do `/volunteers/stats`) + cards com top-border por status + avatar na cor do status |

### Código novo / compartilhado

- `frontend/components/ui/StatusFilterChips.tsx` — componente reutilizável de chips com dot + label + contagem (fill colorido quando ativo)
- `frontend/lib/chart-colors.ts` — novos maps:
  - `CAMPAIGN_STATUS_STYLE` + `CAMPAIGN_STATUS_ORDER`
  - `EVENT_STATUS_STYLE` + `EVENT_STATUS_ORDER`
  - `VOLUNTEER_STATUS_STYLE` + `VOLUNTEER_STATUS_ORDER`
- `frontend/app/finance/page.tsx` — tipo `FinanceStatusCfg` extendido com `stripe` (hex) + `tint` (hex) para aplicar `boxShadow: inset 4px 0 0 ...` nas linhas
- `frontend/app/donations/page.tsx` — componente local `FilterChip` + reuso de `donationTypeColor()` / `statusColor()`

Paleta (consistente entre páginas):
- verde `#16a34a` → ativo / recebido / pago / monetário
- navy `#22518a` → concluído
- amber `#f59e0b` → pausado / pendente
- azul `#3b82f6` → agendado / a pagar
- índigo `#6366f1` → a receber
- vermelho `#dc2626` → cancelado / vencido / suspenso
- laranja `#f97316` → estornado
- slate `#94a3b8` → rascunho / inativo

API/Prisma/rotinas **não** foram tocadas. Só UI.

## Review & Testing Checklist for Human

- [ ] Entrar em `/campaigns` e clicar em cada chip — cards devem filtrar e mudar de cor por status (top-border 4px)
- [ ] Entrar em `/events` e conferir o mesmo comportamento
- [ ] Em `/finance` → aba **A Pagar** e **A Receber**, conferir que cada linha tem stripe colorido à esquerda (inset box-shadow) + tint de fundo, e que chip ativo fica com fill sólido
- [ ] Em `/donations`, testar filtros **Tipo** e **Status** simultâneos — combinações devem funcionar; linhas devem exibir stripe lateral pela cor do tipo
- [ ] Em `/volunteers`, conferir que a contagem dos chips vem certa de `/volunteers/stats` (active/pending/inactive/suspended) e que avatar/top-border pegam a cor do status
- [ ] Regressão: criar/editar/concluir um cadastro qualquer ainda funciona normalmente (nenhum handler foi tocado)

### Notes

- Build local `npm run build` passa 18/18 páginas.
- CI continua sem workflow (`.github/workflows/ci.yml` depende de `cp docs/ci.yml ...` manual).
- Próximo PR: redesign do portal público `/portal/voluntarios-unidos` focado em conversão (doação/voluntário), conforme seu último pedido.

Link to Devin session: https://app.devin.ai/sessions/4719aaf8036145abb9f48deb1f2978a0
Requested by: @fredsontocantins