### PR TITLE
feat(portal): high-conversion public portal with donation + volunteer intent CTAs

### DIFF
--- a/backend/src/modules/public/dto/donation-intent.dto.ts
+++ b/backend/src/modules/public/dto/donation-intent.dto.ts
@@ -1,0 +1,56 @@
+import {
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator'
+import { DonationType } from '@prisma/client'
+
+export class PublicDonationIntentDto {
+  @IsString() @IsNotEmpty() @MaxLength(120)
+  nome!: string
+
+  @IsEmail() @MaxLength(255)
+  email!: string
+
+  @IsOptional() @IsString() @MaxLength(30)
+  telefone?: string
+
+  @IsOptional() @IsEnum(DonationType)
+  tipo?: DonationType
+
+  @IsOptional() @IsNumber() @Min(1) @Max(10_000_000)
+  valor?: number
+
+  @IsOptional() @IsString() @MaxLength(1000)
+  mensagem?: string
+
+  @IsOptional() @IsInt() @Min(1)
+  campaignId?: number
+}
+
+export class PublicVolunteerIntentDto {
+  @IsString() @IsNotEmpty() @MaxLength(120)
+  nome!: string
+
+  @IsEmail() @MaxLength(255)
+  email!: string
+
+  @IsOptional() @IsString() @MaxLength(30)
+  telefone?: string
+
+  @IsOptional() @IsString() @MaxLength(120)
+  profissao?: string
+
+  @IsOptional() @IsString() @MaxLength(1000)
+  mensagem?: string
+
+  @IsOptional() @IsInt() @Min(1)
+  campaignId?: number
+}

--- a/backend/src/modules/public/public.controller.ts
+++ b/backend/src/modules/public/public.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Param, Query, ParseIntPipe, Post, Body } from '@nestjs
 import { ApiTags, ApiOperation } from '@nestjs/swagger'
 import { PublicService } from './public.service'
 import { Public } from '../../common/decorators/index'
+import { PublicDonationIntentDto, PublicVolunteerIntentDto } from './dto/donation-intent.dto'
 
 @ApiTags('Portal Público')
 @Controller('public')
@@ -74,5 +75,27 @@ export class PublicController {
   async getCampaignDetail(@Param('slug') slug: string, @Param('id', ParseIntPipe) id: number) {
     const org = await this.service.getOrgBySlug(slug)
     return this.service.getCampaignById(org.id, id)
+  }
+
+  @Post('org/:slug/volunteer-intent')
+  @Public()
+  @ApiOperation({ summary: 'Registrar intenção genérica de voluntariado (portal público)' })
+  async registerVolunteerIntent(
+    @Param('slug') slug: string,
+    @Body() body: PublicVolunteerIntentDto,
+  ) {
+    const org = await this.service.getOrgBySlug(slug)
+    return this.service.registerVolunteerIntent(org.id, body)
+  }
+
+  @Post('org/:slug/donation-intent')
+  @Public()
+  @ApiOperation({ summary: 'Registrar intenção de doação (portal público). Cria Donation com status=PENDING' })
+  async registerDonationIntent(
+    @Param('slug') slug: string,
+    @Body() body: PublicDonationIntentDto,
+  ) {
+    const org = await this.service.getOrgBySlug(slug)
+    return this.service.registerDonationIntent(org.id, body)
   }
 }

--- a/backend/src/modules/public/public.service.ts
+++ b/backend/src/modules/public/public.service.ts
@@ -173,4 +173,71 @@ export class PublicService {
       },
     })
   }
+
+  /** Volunteer intent without a specific campaign (portal generic CTA). */
+  async registerVolunteerIntent(
+    orgId: number,
+    data: { nome: string; email: string; telefone?: string; profissao?: string; mensagem?: string; campaignId?: number },
+  ) {
+    let campaignId = data.campaignId
+    if (!campaignId) {
+      const campaign = await this.prisma.campaign.findFirst({
+        where: { organizationId: orgId, publicavel: true, status: 'ACTIVE' },
+        orderBy: [{ destaque: 'desc' }, { createdAt: 'desc' }],
+        select: { id: true },
+      })
+      if (!campaign) throw new NotFoundException('Nenhuma campanha pública disponível')
+      campaignId = campaign.id
+    } else {
+      const campaign = await this.prisma.campaign.findFirst({
+        where: { id: campaignId, organizationId: orgId, publicavel: true },
+        select: { id: true },
+      })
+      if (!campaign) throw new NotFoundException('Campanha não encontrada')
+    }
+
+    return this.prisma.campaignInterest.create({
+      data: {
+        campaignId,
+        organizationId: orgId,
+        nome: data.nome,
+        email: data.email,
+        telefone: data.telefone,
+        profissao: data.profissao,
+        mensagem: data.mensagem,
+      },
+    })
+  }
+
+  /**
+   * Public donation intent. Creates a Donation record with status=PENDING
+   * so that the organization admin can confirm/follow up offline (PIX, transfer, etc).
+   */
+  async registerDonationIntent(
+    orgId: number,
+    data: { nome: string; email: string; telefone?: string; tipo?: any; valor?: number; mensagem?: string; campaignId?: number },
+  ) {
+    if (data.campaignId) {
+      const campaign = await this.prisma.campaign.findFirst({
+        where: { id: data.campaignId, organizationId: orgId, publicavel: true },
+        select: { id: true },
+      })
+      if (!campaign) throw new NotFoundException('Campanha não encontrada')
+    }
+
+    return this.prisma.donation.create({
+      data: {
+        organizationId: orgId,
+        campaignId: data.campaignId ?? null,
+        tipo: data.tipo ?? 'MONETARY',
+        valor: data.valor ?? null,
+        status: 'PENDING',
+        doadorNome: data.nome,
+        doadorEmail: data.email,
+        doadorTelefone: data.telefone ?? null,
+        mensagem: data.mensagem ?? null,
+      },
+      select: { id: true, status: true, tipo: true, valor: true },
+    })
+  }
 }

--- a/frontend/app/portal/[slug]/page.tsx
+++ b/frontend/app/portal/[slug]/page.tsx
@@ -1,11 +1,60 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { api } from '@/lib/api'
-import { Users, Target, Heart, Clock, Calendar, MapPin, ArrowRight, Award, Leaf, CheckCircle2, Star } from 'lucide-react'
+import {
+  Users,
+  Heart,
+  Clock,
+  Calendar,
+  MapPin,
+  ArrowRight,
+  Star,
+  HandHeart,
+  Sparkles,
+  CheckCircle2,
+  ShieldCheck,
+  Share2,
+  Trophy,
+  Flame,
+  Megaphone,
+  ArrowUpRight,
+} from 'lucide-react'
 import PortalNav from '@/components/portal/PortalNav'
+import DonateModal from '@/components/portal/DonateModal'
+import VolunteerModal from '@/components/portal/VolunteerModal'
 
 interface PortalProps { params: { slug: string } }
+
+const fmtBRL = (n: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0 }).format(n)
+const fmt = (n: number) => new Intl.NumberFormat('pt-BR').format(n)
+const pct = (v: number, m: number) => m > 0 ? Math.min(100, Math.round((v / m) * 100)) : 0
+
+function useCountUp(target: number, duration = 1200) {
+  const [value, setValue] = useState(0)
+  useEffect(() => {
+    if (!target) { setValue(0); return }
+    const start = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - Math.pow(1 - t, 3)
+      setValue(Math.round(target * eased))
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [target, duration])
+  return value
+}
+
+function daysUntil(date: string | Date | null | undefined) {
+  if (!date) return null
+  const d = new Date(date)
+  if (Number.isNaN(d.getTime())) return null
+  const diff = Math.ceil((d.getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+  return diff
+}
 
 export default function PortalHome({ params }: PortalProps) {
   const { slug } = params
@@ -17,53 +66,66 @@ export default function PortalHome({ params }: PortalProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
+  const [donateOpen, setDonateOpen] = useState(false)
+  const [volOpen, setVolOpen] = useState(false)
+  const [preselectCampaignId, setPreselectCampaignId] = useState<number | undefined>(undefined)
+
   useEffect(() => {
-    let isCancelled = false
+    let cancelled = false
     setLoading(true)
     setError('')
     Promise.allSettled([
       api.publicGetOrg(slug),
       api.publicGetStats(slug),
-      api.publicGetCampaigns(slug, { limit: 6 }),
+      api.publicGetCampaigns(slug, { limit: 9 }),
       api.publicGetEvents(slug, { limit: 6 }),
-      api.publicGetLeaderboard(slug, { limit: 8 }),
-    ])
-      .then(([orgResult, statsResult, campaignsResult, eventsResult, leaderboardResult]) => {
-        if (isCancelled) return
-        if (orgResult.status === 'fulfilled') {
-          setOrg(orgResult.value)
-        } else {
-          setError('Portal não encontrado ou indisponível.')
-          return
-        }
-
-        if (statsResult.status === 'fulfilled') setStats(statsResult.value)
-        if (campaignsResult.status === 'fulfilled') setCampaigns(campaignsResult.value.data || [])
-        else setCampaigns([])
-        if (eventsResult.status === 'fulfilled') setEvents(eventsResult.value.data || [])
-        else setEvents([])
-        if (leaderboardResult.status === 'fulfilled') setLeaderboard(leaderboardResult.value)
-        else setLeaderboard([])
-      })
-      .catch(() => {
-        if (!isCancelled) setError('Portal não encontrado ou indisponível.')
-      })
-      .finally(() => {
-        if (!isCancelled) setLoading(false)
-      })
-
-    return () => { isCancelled = true }
+      api.publicGetLeaderboard(slug, { limit: 6 }),
+    ]).then(([o, s, c, e, l]) => {
+      if (cancelled) return
+      if (o.status === 'fulfilled') setOrg(o.value)
+      else { setError('Portal não encontrado ou indisponível.'); return }
+      if (s.status === 'fulfilled') setStats(s.value)
+      if (c.status === 'fulfilled') setCampaigns(c.value?.data ?? [])
+      if (e.status === 'fulfilled') setEvents(e.value?.data ?? [])
+      if (l.status === 'fulfilled') setLeaderboard(l.value ?? [])
+    }).finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
   }, [slug])
 
-  const fmtBRL = (n: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 0 }).format(n)
-  const fmt = (n: number) => new Intl.NumberFormat('pt-BR').format(n)
-  const pct = (v: number, m: number) => m > 0 ? Math.min(100, Math.round((v / m) * 100)) : 0
+  const simpleCampaigns = useMemo(
+    () => campaigns.map((c: any) => ({ id: c.id, nome: c.nome })),
+    [campaigns],
+  )
+
+  const featured = useMemo(() => {
+    if (!campaigns.length) return null
+    return campaigns.find((c: any) => c.destaque) ?? campaigns[0]
+  }, [campaigns])
+
+  // animated counters
+  const aVolunteers = useCountUp(stats?.voluntariosAtivos ?? 0)
+  const aCampaigns = useCountUp(stats?.campanhasAtivas ?? 0)
+  const aHours = useCountUp(stats?.totalHoras ?? 0)
+  const aEvents = useCountUp(stats?.eventosAgendados ?? 0)
+  const aArrecadado = useCountUp(Math.round(stats?.totalArrecadado ?? 0))
+
+  const openDonate = (campaignId?: number) => { setPreselectCampaignId(campaignId); setDonateOpen(true) }
+  const openVolunteer = (campaignId?: number) => { setPreselectCampaignId(campaignId); setVolOpen(true) }
+
+  const share = async () => {
+    const url = typeof window !== 'undefined' ? window.location.href : ''
+    const text = `Apoie ${org?.name ?? 'esta causa'}`
+    try {
+      if (navigator.share) await navigator.share({ title: text, url })
+      else { await navigator.clipboard.writeText(url); alert('Link copiado!') }
+    } catch { /* user cancel */ }
+  }
 
   if (loading) return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-brand-50 to-brand-50 flex items-center justify-center">
+    <div className="min-h-screen bg-gradient-to-br from-brand-50 via-white to-brand-50 flex items-center justify-center">
       <div className="flex flex-col items-center gap-4">
-        <div className="w-16 h-16 bg-white rounded-3xl shadow-lg flex items-center justify-center animate-bounce">
-          <Leaf size={28} className="text-brand-500" />
+        <div className="w-16 h-16 bg-white rounded-3xl shadow-lg flex items-center justify-center animate-pulse">
+          <Heart size={28} className="text-brand-600" />
         </div>
         <p className="text-brand-700 font-semibold text-sm">Carregando portal...</p>
       </div>
@@ -79,141 +141,238 @@ export default function PortalHome({ params }: PortalProps) {
     </div>
   )
 
+  const featuredProgress = featured ? pct(featured.arrecadado, featured.metaArrecadacao || 0) : 0
+  const featuredRemain = featured ? Math.max(0, (featured.metaArrecadacao || 0) - (featured.arrecadado || 0)) : 0
+  const featuredDays = featured ? daysUntil(featured.dataFim) : null
+
   return (
-    <div className="portal-content text-white">
+    <div className="portal-content text-slate-900 pb-28 md:pb-0">
+      <PortalNav slug={slug} orgName={org?.name}>
+        <button onClick={() => openDonate()}
+          className="hidden md:inline-flex items-center gap-1.5 px-4 py-2 rounded-full bg-amber-400 text-amber-900 text-sm font-black shadow-sm hover:bg-amber-300 transition">
+          <HandHeart size={15} /> Doar agora
+        </button>
+      </PortalNav>
 
-      {/* ── NAV ── */}
-      <PortalNav slug={slug} orgName={org?.name} />
-
-      {/* ── HERO ── */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-brand-500 via-brand-400 to-brand-600 text-white">
-        {/* Fun background shapes */}
-        <div className="absolute inset-0 pointer-events-none overflow-hidden">
-          <div className="absolute -top-20 -right-20 w-80 h-80 bg-white/10 rounded-full" />
-          <div className="absolute -bottom-10 -left-16 w-60 h-60 bg-white/10 rounded-full" />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-white/5 rounded-full" />
-          {/* Dots pattern */}
-          <div className="absolute inset-0 opacity-20" style={{
-            backgroundImage: 'radial-gradient(circle, white 1px, transparent 1px)',
-            backgroundSize: '32px 32px'
+      {/* ══════════════════════ HERO ══════════════════════ */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-brand-700 via-brand-600 to-brand-500 text-white">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-32 -right-20 w-[480px] h-[480px] bg-amber-300/20 rounded-full blur-3xl" />
+          <div className="absolute -bottom-32 -left-20 w-[520px] h-[520px] bg-cyan-300/20 rounded-full blur-3xl" />
+          <div className="absolute inset-0 opacity-[0.12]" style={{
+            backgroundImage: 'radial-gradient(circle, white 1px, transparent 1.2px)',
+            backgroundSize: '28px 28px'
           }} />
         </div>
 
-        <div className="relative max-w-6xl mx-auto px-6 py-24 text-center">
-          <div className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/20 backdrop-blur-sm border border-white/30 text-white text-sm font-bold mb-8">
-            <span className="w-2 h-2 bg-yellow-300 rounded-full animate-pulse" />
-            Portal Público · {org?.city || 'Brasil'} 🌱
+        <div className="relative max-w-6xl mx-auto px-6 pt-16 pb-20 md:pt-24 md:pb-28 grid md:grid-cols-[1.15fr_1fr] gap-10 items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-white/15 backdrop-blur border border-white/25 text-xs font-bold uppercase tracking-wider mb-6">
+              <span className="w-2 h-2 bg-amber-300 rounded-full animate-pulse" />
+              {org?.city ? `${org.city}, ${org.state ?? 'Brasil'}` : 'Portal Público'} · Organização social
+            </div>
+
+            <h1 className="text-[2.4rem] md:text-6xl font-black font-display leading-[1.05] tracking-tight mb-5">
+              Sua ajuda transforma <span className="bg-amber-300 text-brand-900 px-3 rounded-xl">vidas</span> todos os dias.
+            </h1>
+
+            <p className="text-white/85 text-lg md:text-xl max-w-xl mb-8 leading-relaxed">
+              {org?.portalDescricao || org?.description || `A ${org?.name ?? 'nossa organização'} conecta voluntários e doadores para acelerar impacto social em comunidades reais. Basta um clique para começar.`}
+            </p>
+
+            <div className="flex flex-wrap gap-3 mb-8">
+              <button onClick={() => openDonate()}
+                className="group inline-flex items-center gap-2 px-7 py-4 bg-amber-400 hover:bg-amber-300 text-brand-900 font-black rounded-2xl shadow-xl shadow-amber-500/30 hover:-translate-y-0.5 transition-all text-base">
+                <HandHeart size={18} /> Doar agora
+                <ArrowRight size={16} className="group-hover:translate-x-0.5 transition" />
+              </button>
+              <button onClick={() => openVolunteer()}
+                className="inline-flex items-center gap-2 px-7 py-4 bg-white/15 backdrop-blur text-white font-black rounded-2xl border-2 border-white/40 hover:bg-white/25 hover:-translate-y-0.5 transition-all text-base">
+                <Users size={18} /> Quero ser voluntário
+              </button>
+            </div>
+
+            {/* trust row */}
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-white/80">
+              <span className="flex items-center gap-1.5"><ShieldCheck size={14} className="text-emerald-300" /> Doação registrada e rastreável</span>
+              <span className="flex items-center gap-1.5"><Sparkles size={14} className="text-amber-300" /> Equipe entra em contato em 24h</span>
+              <span className="flex items-center gap-1.5"><Heart size={14} className="text-rose-300" /> 100% do recurso vai pra causa</span>
+            </div>
           </div>
 
-          <h1 className="text-5xl md:text-6xl font-black font-display leading-tight mb-5 drop-shadow-sm">
-            Transforme vidas com<br />
-            <span className="bg-white/25 px-4 rounded-2xl">seu voluntariado! 🤝</span>
-          </h1>
+          {/* HERO CARD — live featured campaign */}
+          {featured ? (
+            <div className="relative">
+              <div className="absolute -top-4 -right-4 bg-amber-400 text-brand-900 px-3 py-1 rounded-full text-[11px] font-black shadow-lg flex items-center gap-1 z-10">
+                <Flame size={12} /> URGENTE
+              </div>
+              <div className="bg-white rounded-3xl shadow-2xl shadow-black/30 border border-white/20 p-6 text-slate-800">
+                <p className="text-[11px] uppercase tracking-[0.25em] text-brand-600 font-bold mb-1">Campanha em destaque</p>
+                <h3 className="text-xl font-black font-display leading-snug mb-3">{featured.nome}</h3>
+                <p className="text-sm text-slate-500 line-clamp-2 mb-4">{featured.descricao || 'Contribua para que esta causa avance mais rápido.'}</p>
 
-          <p className="text-white/85 text-lg max-w-2xl mx-auto mb-10 leading-relaxed">
-            {org?.portalDescricao || org?.description || 'Junte-se a nós e ajude a transformar comunidades com seu tempo e talento.'}
-          </p>
+                {featured.metaArrecadacao > 0 && (
+                  <>
+                    <div className="flex items-end justify-between text-xs mb-1.5">
+                      <span className="text-slate-500">Arrecadado</span>
+                      <span className="text-brand-700 font-black text-lg leading-none">{fmtBRL(featured.arrecadado || 0)}</span>
+                    </div>
+                    <div className="h-3 bg-slate-100 rounded-full overflow-hidden mb-1.5">
+                      <div className="h-full bg-gradient-to-r from-emerald-400 to-brand-500 rounded-full transition-all duration-700"
+                        style={{ width: `${featuredProgress}%` }} />
+                    </div>
+                    <div className="flex items-center justify-between text-xs text-slate-500 mb-4">
+                      <span><span className="font-bold text-brand-700">{featuredProgress}%</span> da meta {fmtBRL(featured.metaArrecadacao)}</span>
+                      <span>Faltam <span className="font-bold text-rose-600">{fmtBRL(featuredRemain)}</span></span>
+                    </div>
+                  </>
+                )}
 
-          <div className="flex items-center justify-center gap-4 flex-wrap">
-            <Link href={`/portal/${slug}/campaigns`}
-              className="inline-flex items-center gap-2 px-8 py-4 bg-white text-brand-600 font-black rounded-2xl shadow-xl hover:-translate-y-1 transition-all text-sm">
-              Ver Campanhas <ArrowRight size={16} />
-            </Link>
-            <Link href={`/portal/${slug}/leaderboard`}
-              className="inline-flex items-center gap-2 px-8 py-4 bg-white/20 backdrop-blur-sm text-white font-bold rounded-2xl border-2 border-white/40 hover:bg-white/30 hover:-translate-y-1 transition-all text-sm">
-              🏆 Ver Ranking
-            </Link>
-          </div>
+                <div className="flex items-center gap-3 text-xs text-slate-600 mb-5">
+                  <span className="inline-flex items-center gap-1"><Users size={13} className="text-brand-600" /> {featured.voluntariosAtivos ?? 0} voluntários</span>
+                  <span className="inline-flex items-center gap-1"><Heart size={13} className="text-rose-500" /> {featured._count?.donations ?? 0} doações</span>
+                  {featuredDays !== null && featuredDays >= 0 && featuredDays <= 60 && (
+                    <span className="inline-flex items-center gap-1 text-amber-700 font-bold"><Clock size={13} /> {featuredDays === 0 ? 'último dia' : `${featuredDays} dias restantes`}</span>
+                  )}
+                </div>
+
+                <button onClick={() => openDonate(featured.id)}
+                  className="w-full inline-flex items-center justify-center gap-2 px-5 py-3.5 rounded-2xl bg-gradient-to-r from-brand-600 to-brand-500 hover:from-brand-700 hover:to-brand-600 text-white font-black shadow-lg hover:-translate-y-0.5 transition">
+                  <HandHeart size={16} /> Apoiar esta campanha
+                </button>
+                <button onClick={() => openVolunteer(featured.id)}
+                  className="mt-2 w-full inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-2xl border-2 border-brand-100 hover:border-brand-300 text-brand-700 font-bold text-sm transition">
+                  Quero ser voluntário dessa causa
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-3xl bg-white/10 border border-white/20 p-8 text-center">
+              <Megaphone size={32} className="mx-auto mb-3 text-white/70" />
+              <p className="text-white/80 text-sm">Em breve, novas campanhas.</p>
+            </div>
+          )}
         </div>
 
-        {/* Wave bottom */}
-        <div className="absolute bottom-0 left-0 right-0">
+        {/* wave */}
+        <div className="absolute bottom-0 left-0 right-0 pointer-events-none">
           <svg viewBox="0 0 1440 60" className="w-full fill-white" preserveAspectRatio="none">
             <path d="M0,60 C360,0 1080,0 1440,60 L1440,60 L0,60 Z" />
           </svg>
         </div>
       </section>
 
-      {/* ── STATS ── */}
+      {/* ══════════════════════ IMPACT / SOCIAL PROOF ══════════════════════ */}
       {stats && (
-        <section className="max-w-6xl mx-auto px-6 py-16">
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-            {[
-              { label: 'Voluntários', value: fmt(stats.voluntariosAtivos), emoji: '🙋', bg: 'from-blue-400 to-indigo-500', light: 'bg-blue-50 border-blue-100' },
-              { label: 'Campanhas', value: fmt(stats.campanhasAtivas), emoji: '📢', bg: 'from-brand-400 to-brand-500', light: 'bg-brand-50 border-brand-100' },
-              { label: 'Arrecadado', value: fmtBRL(stats.totalArrecadado), emoji: '💰', bg: 'from-amber-400 to-orange-500', light: 'bg-amber-50 border-amber-100' },
-              { label: 'Horas Doadas', value: fmt(stats.totalHoras) + 'h', emoji: '⏰', bg: 'from-pink-400 to-rose-500', light: 'bg-pink-50 border-pink-100' },
-              { label: 'Eventos', value: fmt(stats.eventosAgendados), emoji: '📅', bg: 'from-purple-400 to-violet-500', light: 'bg-purple-50 border-purple-100' },
-            ].map(s => (
-              <div key={s.label} className={`${s.light} border rounded-3xl p-5 text-center hover:-translate-y-1 transition-all duration-300`}>
-                <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${s.bg} flex items-center justify-center text-2xl mx-auto mb-3 shadow-lg`}>
-                  {s.emoji}
-                </div>
-                <p className="text-2xl font-black text-slate-900 font-display">{s.value}</p>
-                <p className="text-slate-500 text-xs font-semibold mt-1">{s.label}</p>
+        <section className="max-w-6xl mx-auto px-6 -mt-6 md:-mt-10 relative z-10">
+          <div className="bg-white rounded-3xl shadow-xl border border-slate-100 p-6 md:p-8">
+            <div className="flex items-center justify-between gap-3 mb-6">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.35em] text-brand-600">Impacto coletivo</p>
+                <h2 className="text-xl md:text-2xl font-black font-display text-slate-900">Juntos já fizemos muito</h2>
               </div>
-            ))}
+              <button onClick={share}
+                className="hidden md:inline-flex items-center gap-1.5 px-3 py-2 rounded-full text-xs font-bold text-brand-700 bg-brand-50 hover:bg-brand-100 transition">
+                <Share2 size={13} /> Compartilhar
+              </button>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+              {[
+                { label: 'Voluntários ativos', value: fmt(aVolunteers), icon: Users, color: 'text-sky-600', bg: 'bg-sky-50' },
+                { label: 'Campanhas abertas', value: fmt(aCampaigns), icon: Megaphone, color: 'text-brand-700', bg: 'bg-brand-50' },
+                { label: 'Arrecadado', value: fmtBRL(aArrecadado), icon: HandHeart, color: 'text-emerald-600', bg: 'bg-emerald-50' },
+                { label: 'Horas doadas', value: `${fmt(aHours)}h`, icon: Clock, color: 'text-rose-600', bg: 'bg-rose-50' },
+                { label: 'Eventos próximos', value: fmt(aEvents), icon: Calendar, color: 'text-violet-600', bg: 'bg-violet-50' },
+              ].map(s => (
+                <div key={s.label} className="rounded-2xl border border-slate-100 bg-white p-4 hover:border-brand-200 hover:shadow-md transition">
+                  <div className={`w-9 h-9 rounded-xl ${s.bg} flex items-center justify-center mb-2`}>
+                    <s.icon size={16} className={s.color} />
+                  </div>
+                  <p className="text-2xl font-black text-slate-900 font-display leading-none">{s.value}</p>
+                  <p className="text-[11px] font-semibold text-slate-500 mt-1">{s.label}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       )}
 
-      {/* ── CAMPANHAS ── */}
+      {/* ══════════════════════ CAMPANHAS ══════════════════════ */}
       {campaigns.length > 0 && (
-        <section className="max-w-6xl mx-auto px-6 pb-20">
-          <div className="flex items-end justify-between mb-8">
+        <section className="max-w-6xl mx-auto px-6 py-20">
+          <div className="flex items-end justify-between mb-8 flex-wrap gap-4">
             <div>
-              <span className="inline-block px-3 py-1 bg-brand-100 text-brand-700 rounded-full text-xs font-bold uppercase tracking-wide mb-3">
-                💚 Em andamento
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-brand-50 text-brand-700 rounded-full text-[11px] font-black uppercase tracking-wide mb-3 border border-brand-100">
+                <Megaphone size={12} /> Em andamento
               </span>
-              <h2 className="text-3xl font-black font-display text-slate-900">Campanhas Ativas</h2>
+              <h2 className="text-3xl md:text-4xl font-black font-display text-slate-900">Onde sua ajuda entra agora</h2>
+              <p className="text-slate-500 mt-2 max-w-xl">Escolha uma causa e contribua com o valor que puder — cada real aproxima a meta.</p>
             </div>
             <Link href={`/portal/${slug}/campaigns`}
-              className="text-brand-600 hover:text-brand-700 text-sm font-bold flex items-center gap-1 bg-brand-50 px-4 py-2 rounded-xl hover:bg-brand-100 transition-all">
+              className="text-brand-700 hover:text-brand-800 text-sm font-bold flex items-center gap-1 bg-brand-50 hover:bg-brand-100 px-4 py-2 rounded-xl transition">
               Ver todas <ArrowRight size={14} />
             </Link>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {campaigns.slice(0, 6).map((c: any, idx: number) => {
-              const gradients = [
-                'from-brand-400 to-brand-500',
-                'from-blue-400 to-indigo-500',
-                'from-orange-400 to-amber-500',
-                'from-pink-400 to-rose-500',
-                'from-purple-400 to-violet-500',
-                'from-brand-400 to-blue-500',
-              ]
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            {campaigns.slice(0, 6).map((c: any) => {
               const prog = pct(c.arrecadado, c.metaArrecadacao || 0)
+              const remain = Math.max(0, (c.metaArrecadacao || 0) - (c.arrecadado || 0))
+              const d = daysUntil(c.dataFim)
+              const urgent = d !== null && d >= 0 && d <= 15
+              const tone =
+                prog >= 80 ? { bar: '#16a34a', chip: 'bg-emerald-50 text-emerald-700 border-emerald-200', chipLabel: `🎯 ${prog}% da meta` } :
+                urgent ? { bar: '#dc2626', chip: 'bg-rose-50 text-rose-700 border-rose-200', chipLabel: d === 0 ? '🔥 Último dia' : `🔥 Faltam ${d} dias` } :
+                c.destaque ? { bar: '#f59e0b', chip: 'bg-amber-50 text-amber-700 border-amber-200', chipLabel: '⭐ Destaque' } :
+                { bar: '#22518a', chip: 'bg-brand-50 text-brand-700 border-brand-200', chipLabel: 'Em andamento' }
+
               return (
-                <div key={c.id} className="bg-white rounded-3xl border-2 border-slate-100 overflow-hidden hover:-translate-y-1 hover:shadow-xl transition-all duration-300 group">
-                  {/* Card top color bar */}
-                  <div className={`h-2 bg-gradient-to-r ${gradients[idx % 6]}`} />
-                  <div className="p-6">
-                    {c.destaque && (
-                      <div className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-bold mb-3">
-                        ⭐ Destaque
-                      </div>
-                    )}
-                    <h3 className="font-black text-slate-900 text-base mb-2 group-hover:text-brand-600 transition-colors">{c.nome}</h3>
-                    <p className="text-slate-500 text-sm mb-4 line-clamp-2 leading-relaxed">{c.descricao}</p>
+                <div key={c.id}
+                  className="group bg-white rounded-3xl border border-slate-100 overflow-hidden hover:-translate-y-1 hover:shadow-xl transition-all duration-300 flex flex-col">
+                  <div className="h-1.5" style={{ backgroundColor: tone.bar }} />
+                  <div className="p-5 flex-1 flex flex-col">
+                    <div className="flex items-start justify-between gap-2 mb-3">
+                      <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-[10px] font-black uppercase tracking-wide ${tone.chip}`}>
+                        {tone.chipLabel}
+                      </span>
+                      {c._count?.donations > 0 && (
+                        <span className="text-[10px] text-slate-400 font-semibold flex items-center gap-1">
+                          <Heart size={11} className="text-rose-500" /> {c._count.donations}
+                        </span>
+                      )}
+                    </div>
 
-                    {c.metaArrecadacao && (
+                    <h3 className="font-black text-slate-900 text-base mb-1 group-hover:text-brand-700 transition line-clamp-2">{c.nome}</h3>
+                    <p className="text-slate-500 text-sm mb-4 line-clamp-2 flex-1">{c.descricao}</p>
+
+                    {c.metaArrecadacao > 0 && (
                       <div className="mb-4">
-                        <div className="flex justify-between text-xs mb-2">
-                          <span className="text-slate-500 font-medium">{fmtBRL(c.arrecadado)}</span>
-                          <span className="font-black text-brand-600">{prog}%</span>
+                        <div className="flex justify-between text-[11px] mb-1.5">
+                          <span className="text-slate-500 font-semibold">{fmtBRL(c.arrecadado || 0)}</span>
+                          <span className="font-black text-slate-700">{prog}%</span>
                         </div>
-                        <div className="h-3 bg-slate-100 rounded-full overflow-hidden">
-                          <div className={`h-full bg-gradient-to-r ${gradients[idx % 6]} rounded-full transition-all duration-700`}
-                            style={{ width: `${prog}%` }} />
+                        <div className="h-2.5 bg-slate-100 rounded-full overflow-hidden">
+                          <div className="h-full rounded-full transition-all duration-700"
+                            style={{ width: `${prog}%`, backgroundColor: tone.bar }} />
                         </div>
-                        <p className="text-xs text-slate-400 mt-1 text-right">meta {fmtBRL(c.metaArrecadacao)}</p>
+                        <p className="text-[11px] text-slate-400 mt-1">
+                          {remain > 0
+                            ? <>Faltam <span className="font-bold text-slate-700">{fmtBRL(remain)}</span> para bater a meta</>
+                            : <>Meta atingida! 🎉</>}
+                        </p>
                       </div>
                     )}
 
-                    <div className="flex items-center gap-3 text-xs text-slate-500 pt-3 border-t border-slate-100">
-                      <span className="flex items-center gap-1">👥 {c.voluntariosAtivos} vol.</span>
-                      <span className="flex items-center gap-1">💝 {c._count?.donations || 0} doações</span>
+                    <div className="flex gap-2 mt-auto">
+                      <button onClick={() => openDonate(c.id)}
+                        className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl bg-brand-600 hover:bg-brand-700 text-white font-bold text-sm transition">
+                        <HandHeart size={14} /> Doar
+                      </button>
+                      <button onClick={() => openVolunteer(c.id)}
+                        className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-xl border-2 border-brand-100 hover:border-brand-300 text-brand-700 font-bold text-sm transition">
+                        <Users size={14} /> Ajudar
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -223,84 +382,109 @@ export default function PortalHome({ params }: PortalProps) {
         </section>
       )}
 
-      {/* ── EVENTOS ── */}
+      {/* ══════════════════════ EVENTOS ══════════════════════ */}
       {events.length > 0 && (
-        <section className="bg-gradient-to-br from-slate-50 to-blue-50 py-20">
+        <section className="bg-gradient-to-br from-slate-50 to-brand-50/40 py-20 border-y border-slate-100">
           <div className="max-w-6xl mx-auto px-6">
-            <div className="mb-8">
-              <span className="inline-block px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-bold uppercase tracking-wide mb-3">
-                📅 Agenda
-              </span>
-              <h2 className="text-3xl font-black font-display text-slate-900">Próximos Eventos</h2>
+            <div className="flex items-end justify-between mb-8 flex-wrap gap-4">
+              <div>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white text-brand-700 rounded-full text-[11px] font-black uppercase tracking-wide mb-3 border border-brand-100 shadow-sm">
+                  <Calendar size={12} /> Agenda aberta
+                </span>
+                <h2 className="text-3xl md:text-4xl font-black font-display text-slate-900">Próximos eventos</h2>
+                <p className="text-slate-500 mt-2 max-w-xl">Participe presencialmente — é o jeito mais rápido de entender como ajudar.</p>
+              </div>
             </div>
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {events.slice(0, 4).map((ev: any) => (
-                <div key={ev.id} className="bg-white rounded-2xl border-2 border-slate-100 p-5 flex items-start gap-4 hover:-translate-y-0.5 hover:shadow-lg transition-all">
-                  <div className="text-center bg-gradient-to-br from-blue-400 to-indigo-500 rounded-2xl p-3 w-16 flex-shrink-0 shadow-md">
-                    <p className="text-2xl font-black text-white leading-none">{new Date(ev.dataInicio).getDate()}</p>
-                    <p className="text-[10px] text-blue-100 uppercase mt-0.5 font-bold">
-                      {new Date(ev.dataInicio).toLocaleDateString('pt-BR', { month: 'short' })}
-                    </p>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-black text-slate-900">{ev.nome}</h3>
-                    {ev.descricao && <p className="text-slate-500 text-sm mt-0.5 line-clamp-1">{ev.descricao}</p>}
-                    {ev.local && (
-                      <div className="flex items-center gap-1 text-xs text-slate-400 mt-2">
-                        <MapPin size={11} className="text-brand-500" />{ev.local}
+              {events.slice(0, 4).map((ev: any) => {
+                const d = new Date(ev.dataInicio)
+                const ongoing = ev.status === 'ONGOING'
+                return (
+                  <div key={ev.id} className="bg-white rounded-2xl border border-slate-100 p-5 flex items-start gap-4 hover:-translate-y-0.5 hover:shadow-lg transition-all">
+                    <div className="text-center bg-gradient-to-br from-brand-600 to-brand-500 rounded-2xl p-3 w-16 flex-shrink-0 shadow-md">
+                      <p className="text-2xl font-black text-white leading-none">{d.getDate()}</p>
+                      <p className="text-[10px] text-white/80 uppercase mt-0.5 font-bold">
+                        {d.toLocaleDateString('pt-BR', { month: 'short' })}
+                      </p>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <h3 className="font-black text-slate-900 truncate">{ev.nome}</h3>
+                        {ongoing && (
+                          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-700 text-[10px] font-black">
+                            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" /> AO VIVO
+                          </span>
+                        )}
                       </div>
-                    )}
-                    {ev.capacidade && (
-                      <div className="flex items-center gap-1 text-xs text-slate-400 mt-1">
-                        <Users size={11} className="text-blue-500" />
-                        {ev._count?.registrations || 0}/{ev.capacidade} inscritos
+                      {ev.descricao && <p className="text-slate-500 text-sm line-clamp-1">{ev.descricao}</p>}
+                      <div className="flex items-center flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500 mt-2">
+                        {ev.local && <span className="flex items-center gap-1"><MapPin size={11} className="text-brand-600" />{ev.local}</span>}
+                        {ev.capacidade && (
+                          <span className="flex items-center gap-1">
+                            <Users size={11} className="text-sky-600" />
+                            {ev._count?.registrations || 0}/{ev.capacidade} inscritos
+                          </span>
+                        )}
+                        {d > new Date() && <span className="flex items-center gap-1 text-amber-700 font-semibold"><Clock size={11} /> {daysUntil(ev.dataInicio)} dias</span>}
                       </div>
-                    )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         </section>
       )}
 
-      {/* ── LEADERBOARD PREVIEW ── */}
+      {/* ══════════════════════ LEADERBOARD ══════════════════════ */}
       {leaderboard.length > 0 && (
         <section className="max-w-6xl mx-auto px-6 py-20">
-          <div className="flex items-end justify-between mb-8">
+          <div className="flex items-end justify-between mb-8 flex-wrap gap-4">
             <div>
-              <span className="inline-block px-3 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-bold uppercase tracking-wide mb-3">
-                🏆 Reconhecimento
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-amber-50 text-amber-700 rounded-full text-[11px] font-black uppercase tracking-wide mb-3 border border-amber-100">
+                <Trophy size={12} /> Reconhecimento
               </span>
-              <h2 className="text-3xl font-black font-display text-slate-900">Top Voluntários</h2>
+              <h2 className="text-3xl md:text-4xl font-black font-display text-slate-900">Quem está fazendo acontecer</h2>
+              <p className="text-slate-500 mt-2 max-w-xl">Pessoas reais doando tempo, skills e coração. Pode ser você na próxima atualização.</p>
             </div>
             <Link href={`/portal/${slug}/leaderboard`}
-              className="text-amber-600 hover:text-amber-700 text-sm font-bold flex items-center gap-1 bg-amber-50 px-4 py-2 rounded-xl hover:bg-amber-100 transition-all">
-              Ver ranking completo <ArrowRight size={14} />
+              className="text-amber-700 hover:text-amber-800 text-sm font-bold flex items-center gap-1 bg-amber-50 hover:bg-amber-100 px-4 py-2 rounded-xl transition">
+              Ver ranking <ArrowRight size={14} />
             </Link>
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
-            {leaderboard.slice(0, 3).map((v: any, i: number) => {
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {leaderboard.slice(0, 6).map((v: any, i: number) => {
               const medals = ['🥇', '🥈', '🥉']
-              const bgs = ['bg-gradient-to-br from-amber-50 to-yellow-100 border-amber-200', 'bg-gradient-to-br from-slate-50 to-slate-100 border-slate-200', 'bg-gradient-to-br from-orange-50 to-amber-50 border-orange-200']
+              const isTop = i < 3
               return (
-                <div key={v.id} className={`rounded-3xl border-2 p-6 text-center hover:-translate-y-1 transition-all duration-300 ${bgs[i]}`}>
-                  <div className="text-4xl mb-3">{medals[i]}</div>
-                  <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-brand-400 to-brand-500 flex items-center justify-center text-white font-black text-xl mx-auto mb-3 shadow-lg">
-                    {v.nome[0].toUpperCase()}
+                <div key={v.id}
+                  className={`rounded-3xl border p-5 hover:-translate-y-1 transition-all duration-300 ${
+                    isTop
+                      ? 'bg-gradient-to-br from-amber-50 via-white to-white border-amber-200'
+                      : 'bg-white border-slate-100'
+                  }`}>
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-brand-600 to-brand-500 flex items-center justify-center text-white font-black text-lg shadow-md">
+                      {v.nome[0]?.toUpperCase()}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-black text-slate-900 truncate">{v.nome} {medals[i] ?? ''}</p>
+                      <p className="text-slate-500 text-xs truncate">{v.profissao || 'Voluntário'}</p>
+                    </div>
                   </div>
-                  <p className="font-black text-slate-900">{v.nome}</p>
-                  <p className="text-slate-500 text-xs mt-0.5">{v.profissao || '—'}</p>
-                  <div className="flex items-center justify-center gap-1 mt-3 bg-white rounded-xl px-3 py-2 shadow-sm">
-                    <Star size={13} className="fill-amber-400 text-amber-400" />
-                    <span className="font-black text-slate-800 text-sm">{fmt(v.pontos)}</span>
-                    <span className="text-slate-400 text-xs">pts</span>
+                  <div className="flex items-center justify-between bg-white rounded-xl px-3 py-2 border border-slate-100">
+                    <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Pontos</span>
+                    <span className="flex items-center gap-1">
+                      <Star size={13} className="fill-amber-400 text-amber-400" />
+                      <span className="font-black text-slate-800 text-sm">{fmt(v.pontos)}</span>
+                    </span>
                   </div>
                   {v.badges?.length > 0 && (
-                    <div className="flex justify-center gap-1 mt-2">
+                    <div className="flex gap-1 mt-2">
                       {v.badges.map((b: any, bi: number) => (
-                        <span key={bi} className="text-xl">{b.badge?.icone}</span>
+                        <span key={bi} className="text-lg" title={b.badge?.nome}>{b.badge?.icone}</span>
                       ))}
                     </div>
                   )}
@@ -311,39 +495,135 @@ export default function PortalHome({ params }: PortalProps) {
         </section>
       )}
 
-      {/* ── CTA CERTIFICADO ── */}
-      <section className="bg-gradient-to-r from-brand-600 via-brand-500 to-brand-400 py-16">
-        <div className="max-w-3xl mx-auto px-6 text-center text-white">
-          <div className="text-5xl mb-4">🎓</div>
-          <h2 className="text-3xl font-black font-display mb-3">Verificar Certificado</h2>
-          <p className="text-white/80 mb-8">Confirme a autenticidade de certificados emitidos por esta organização.</p>
+      {/* ══════════════════════ COMO FUNCIONA ══════════════════════ */}
+      <section className="bg-white py-20 border-t border-slate-100">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="text-center mb-10">
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-sky-50 text-sky-700 rounded-full text-[11px] font-black uppercase tracking-wide mb-3 border border-sky-100">
+              Transparência
+            </span>
+            <h2 className="text-3xl md:text-4xl font-black font-display text-slate-900">Como sua doação chega ao destino</h2>
+            <p className="text-slate-500 mt-2 max-w-2xl mx-auto">Processo simples, direto e auditável por cada campanha.</p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {[
+              { n: '1', t: 'Você registra a intenção', d: 'Preenche um formulário rápido com seus dados e o valor que quer doar.', icon: HandHeart, c: 'text-brand-700', b: 'bg-brand-50' },
+              { n: '2', t: 'Equipe confirma em 24h', d: 'A coordenação entra em contato por e-mail ou WhatsApp com as instruções.', icon: CheckCircle2, c: 'text-emerald-600', b: 'bg-emerald-50' },
+              { n: '3', t: 'Recurso aplicado na causa', d: '100% do valor vai para a campanha escolhida, com acompanhamento público.', icon: Sparkles, c: 'text-amber-600', b: 'bg-amber-50' },
+            ].map(step => (
+              <div key={step.n} className="bg-white border-2 border-slate-100 hover:border-brand-200 rounded-3xl p-6 transition relative overflow-hidden">
+                <span className="absolute top-3 right-4 text-[80px] leading-none font-black text-slate-50 select-none">{step.n}</span>
+                <div className={`w-12 h-12 rounded-2xl ${step.b} flex items-center justify-center mb-4 relative`}>
+                  <step.icon size={22} className={step.c} />
+                </div>
+                <h3 className="font-black text-slate-900 text-lg mb-2 relative">{step.t}</h3>
+                <p className="text-sm text-slate-600 leading-relaxed relative">{step.d}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ══════════════════════ CTA FINAL ══════════════════════ */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-brand-700 via-brand-600 to-brand-500 text-white">
+        <div className="absolute inset-0 opacity-20 pointer-events-none" style={{
+          backgroundImage: 'radial-gradient(circle, white 1px, transparent 1px)',
+          backgroundSize: '32px 32px'
+        }} />
+        <div className="relative max-w-4xl mx-auto px-6 py-20 text-center">
+          <div className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-amber-300/20 border border-amber-200/40 text-amber-100 text-xs font-black uppercase tracking-wider mb-5">
+            <Flame size={12} /> Faça parte hoje
+          </div>
+          <h2 className="text-3xl md:text-5xl font-black font-display leading-tight mb-5">
+            Você não precisa ser milionário<br />
+            para mudar a <span className="bg-amber-300 text-brand-900 px-3 rounded-xl">vida de alguém</span>.
+          </h2>
+          <p className="text-white/80 text-lg max-w-2xl mx-auto mb-8">
+            Toda doação é registrada, toda hora de voluntariado é contabilizada, todo impacto fica documentado. Comece agora com um clique.
+          </p>
+          <div className="flex flex-wrap gap-3 justify-center">
+            <button onClick={() => openDonate()}
+              className="inline-flex items-center gap-2 px-8 py-4 bg-amber-400 hover:bg-amber-300 text-brand-900 font-black rounded-2xl shadow-xl shadow-amber-500/30 hover:-translate-y-0.5 transition-all">
+              <HandHeart size={18} /> Doar agora
+            </button>
+            <button onClick={() => openVolunteer()}
+              className="inline-flex items-center gap-2 px-8 py-4 bg-white/15 backdrop-blur text-white font-black rounded-2xl border-2 border-white/40 hover:bg-white/25 hover:-translate-y-0.5 transition-all">
+              <Users size={18} /> Ser voluntário
+            </button>
+            <button onClick={share}
+              className="inline-flex items-center gap-2 px-6 py-4 text-white/80 font-bold hover:text-white transition">
+              <Share2 size={16} /> Compartilhar com amigos
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ══════════════════════ VERIFICAR CERTIFICADO ══════════════════════ */}
+      <section className="bg-white py-16 border-t border-slate-100">
+        <div className="max-w-4xl mx-auto px-6 flex flex-col md:flex-row items-center justify-between gap-6">
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.35em] text-brand-600 mb-1">Autenticidade</p>
+            <h3 className="text-2xl font-black font-display text-slate-900">Verificar certificado de voluntário</h3>
+            <p className="text-slate-500 text-sm mt-1">Confirme validade e integridade de um certificado emitido por esta organização.</p>
+          </div>
           <Link href="/portal/certificate"
-            className="inline-flex items-center gap-2 px-8 py-4 bg-white text-brand-600 font-black rounded-2xl shadow-xl hover:-translate-y-1 transition-all">
-            <CheckCircle2 size={18} /> Verificar agora
+            className="inline-flex items-center gap-2 px-6 py-3 bg-slate-900 hover:bg-slate-800 text-white font-bold rounded-2xl transition whitespace-nowrap">
+            <CheckCircle2 size={16} /> Verificar agora <ArrowUpRight size={14} />
           </Link>
         </div>
       </section>
 
-      {/* ── FOOTER ── */}
+      {/* ══════════════════════ FOOTER ══════════════════════ */}
       <footer className="bg-slate-900 text-white">
         <div className="max-w-6xl mx-auto px-6 py-10 flex flex-col md:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 bg-gradient-to-br from-brand-400 to-brand-500 rounded-xl flex items-center justify-center">
-              <Leaf size={15} className="text-white" />
+            <div className="w-9 h-9 bg-gradient-to-br from-brand-500 to-brand-400 rounded-xl flex items-center justify-center">
+              <Heart size={15} className="text-white" />
             </div>
             <div>
               <p className="font-black text-white">{org?.name}</p>
-              {org?.city && <p className="text-slate-500 text-xs">{org.city}, {org.state}</p>}
+              {org?.city && <p className="text-slate-400 text-xs">{org.city}, {org.state}</p>}
             </div>
           </div>
-          <div className="flex items-center gap-4 text-xs text-slate-500">
-            {org?.email && <span>📧 {org.email}</span>}
-            <Link href="/portal/certificate" className="text-brand-400 hover:text-brand-300 flex items-center gap-1 transition-colors font-semibold">
-              ✅ Verificar Certificado
+          <div className="flex items-center gap-5 text-xs text-slate-400">
+            {org?.email && <a href={`mailto:${org.email}`} className="hover:text-white transition">📧 {org.email}</a>}
+            {org?.website && <a href={org.website} target="_blank" rel="noreferrer" className="hover:text-white transition">🌐 Site</a>}
+            <Link href="/portal/certificate" className="text-brand-300 hover:text-brand-200 flex items-center gap-1 transition font-semibold">
+              Certificado
             </Link>
           </div>
         </div>
       </footer>
+
+      {/* ══════════════════════ STICKY MOBILE CTA ══════════════════════ */}
+      <div className="fixed bottom-0 inset-x-0 md:hidden z-40 bg-white/95 backdrop-blur border-t border-slate-200 p-3 flex gap-2 shadow-[0_-4px_20px_rgba(0,0,0,0.08)]">
+        <button onClick={() => openDonate()}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-3 rounded-2xl bg-amber-400 text-brand-900 font-black text-sm shadow">
+          <HandHeart size={16} /> Doar
+        </button>
+        <button onClick={() => openVolunteer()}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-3 rounded-2xl bg-brand-600 text-white font-black text-sm shadow">
+          <Users size={16} /> Voluntário
+        </button>
+      </div>
+
+      <DonateModal
+        open={donateOpen}
+        onClose={() => setDonateOpen(false)}
+        slug={slug}
+        orgName={org?.name}
+        campaigns={simpleCampaigns}
+        defaultCampaignId={preselectCampaignId}
+      />
+      <VolunteerModal
+        open={volOpen}
+        onClose={() => setVolOpen(false)}
+        slug={slug}
+        orgName={org?.name}
+        campaigns={simpleCampaigns}
+        defaultCampaignId={preselectCampaignId}
+      />
     </div>
   )
 }

--- a/frontend/components/portal/DonateModal.tsx
+++ b/frontend/components/portal/DonateModal.tsx
@@ -1,0 +1,168 @@
+'use client'
+import { useState } from 'react'
+import { CheckCircle2, HandHeart, Loader2 } from 'lucide-react'
+import Modal from '@/components/ui/Modal'
+import { api } from '@/lib/api'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  slug: string
+  orgName?: string
+  campaigns?: Array<{ id: number; nome: string }>
+  defaultCampaignId?: number
+}
+
+const PRESETS = [25, 50, 100, 250, 500]
+const TIPOS = [
+  { value: 'MONETARY', label: 'Dinheiro (PIX)', icon: '💰' },
+  { value: 'FOOD', label: 'Alimento', icon: '🍎' },
+  { value: 'CLOTHING', label: 'Roupa', icon: '👕' },
+  { value: 'MEDICINE', label: 'Remédio', icon: '💊' },
+  { value: 'EQUIPMENT', label: 'Equipamento', icon: '🧰' },
+  { value: 'OTHER', label: 'Outro', icon: '📦' },
+]
+
+export default function DonateModal({ open, onClose, slug, orgName, campaigns = [], defaultCampaignId }: Props) {
+  const [tipo, setTipo] = useState('MONETARY')
+  const [valor, setValor] = useState<number | ''>(100)
+  const [campaignId, setCampaignId] = useState<number | ''>(defaultCampaignId ?? '')
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [mensagem, setMensagem] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState('')
+
+  const reset = () => {
+    setTipo('MONETARY'); setValor(100); setCampaignId(defaultCampaignId ?? '')
+    setNome(''); setEmail(''); setTelefone(''); setMensagem('')
+    setSubmitting(false); setSuccess(false); setError('')
+  }
+
+  const handleClose = () => { reset(); onClose() }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(''); setSubmitting(true)
+    try {
+      const payload: Record<string, any> = { nome, email, tipo }
+      if (telefone) payload.telefone = telefone
+      if (mensagem) payload.mensagem = mensagem
+      if (tipo === 'MONETARY' && valor) payload.valor = Number(valor)
+      if (campaignId) payload.campaignId = Number(campaignId)
+      await api.publicDonationIntent(slug, payload)
+      setSuccess(true)
+    } catch (err: any) {
+      setError(err?.message || 'Não foi possível registrar sua doação.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title={success ? 'Doação registrada!' : 'Quero doar'} size="md">
+      {success ? (
+        <div className="py-4 text-center space-y-4">
+          <div className="w-16 h-16 rounded-full bg-emerald-50 border-4 border-emerald-100 mx-auto flex items-center justify-center">
+            <CheckCircle2 size={32} className="text-emerald-600" />
+          </div>
+          <div>
+            <p className="font-bold text-slate-900 text-lg">Obrigado por doar!</p>
+            <p className="text-slate-600 text-sm mt-1">
+              Registramos sua intenção e a equipe {orgName ? <strong>{orgName}</strong> : 'da organização'} vai entrar em contato em <strong>{email}</strong> com as instruções para concluir sua doação.
+            </p>
+          </div>
+          <button type="button" onClick={handleClose} className="btn-primary w-full justify-center">Fechar</button>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="space-y-4">
+          <p className="text-sm text-slate-600">
+            <HandHeart size={16} className="inline -mt-0.5 mr-1 text-brand-600" />
+            Preencha seus dados e a equipe entra em contato para confirmar a doação.
+          </p>
+
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Tipo de doação</label>
+            <div className="mt-2 grid grid-cols-3 gap-2">
+              {TIPOS.map(t => (
+                <button key={t.value} type="button"
+                  onClick={() => setTipo(t.value)}
+                  className={`rounded-xl border-2 p-2.5 text-xs font-semibold transition ${
+                    tipo === t.value
+                      ? 'border-brand-600 bg-brand-50 text-brand-700'
+                      : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+                  }`}>
+                  <span className="block text-lg mb-0.5">{t.icon}</span>
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {tipo === 'MONETARY' && (
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Valor (R$)</label>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {PRESETS.map(p => (
+                  <button key={p} type="button" onClick={() => setValor(p)}
+                    className={`px-4 py-2 rounded-full text-sm font-bold border-2 transition ${
+                      valor === p ? 'border-brand-600 bg-brand-600 text-white' : 'border-slate-200 text-slate-700 hover:border-brand-300'
+                    }`}>
+                    R$ {p}
+                  </button>
+                ))}
+                <input type="number" min={1} placeholder="Outro valor"
+                  className="input flex-1 min-w-[120px]"
+                  value={typeof valor === 'number' && !PRESETS.includes(valor) ? valor : ''}
+                  onChange={e => setValor(e.target.value ? Number(e.target.value) : '')} />
+              </div>
+            </div>
+          )}
+
+          {campaigns.length > 0 && (
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Destinar para (opcional)</label>
+              <select className="input mt-2" value={campaignId} onChange={e => setCampaignId(e.target.value ? Number(e.target.value) : '')}>
+                <option value="">Onde for mais necessário</option>
+                {campaigns.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
+              </select>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Nome *</label>
+              <input required className="input mt-2" value={nome} onChange={e => setNome(e.target.value)} placeholder="Seu nome" />
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">E-mail *</label>
+              <input required type="email" className="input mt-2" value={email} onChange={e => setEmail(e.target.value)} placeholder="voce@email.com" />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wider text-slate-500">WhatsApp / telefone (opcional)</label>
+            <input className="input mt-2" value={telefone} onChange={e => setTelefone(e.target.value)} placeholder="(11) 99999-9999" />
+          </div>
+
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Mensagem (opcional)</label>
+            <textarea rows={2} className="input mt-2" value={mensagem} onChange={e => setMensagem(e.target.value)} placeholder="Deixe uma mensagem para a equipe" />
+          </div>
+
+          {error && <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">{error}</p>}
+
+          <button type="submit" disabled={submitting} className="btn-primary w-full justify-center">
+            {submitting ? <><Loader2 size={16} className="animate-spin" /> Enviando...</> : <><HandHeart size={16} /> Doar agora</>}
+          </button>
+
+          <p className="text-[11px] text-slate-400 text-center">
+            Sua doação ainda será confirmada pela equipe da organização. Nenhum pagamento é feito nesta etapa.
+          </p>
+        </form>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/components/portal/PortalNav.tsx
+++ b/frontend/components/portal/PortalNav.tsx
@@ -5,9 +5,10 @@ import { Leaf, ArrowRight } from 'lucide-react'
 interface PortalNavProps {
   slug: string
   orgName?: string
+  children?: React.ReactNode
 }
 
-export default function PortalNav({ slug, orgName }: PortalNavProps) {
+export default function PortalNav({ slug, orgName, children }: PortalNavProps) {
   return (
     <nav className="sticky top-0 z-50 portal-nav">
       <div className="max-w-6xl mx-auto px-6 py-3.5 flex items-center justify-between">
@@ -19,14 +20,15 @@ export default function PortalNav({ slug, orgName }: PortalNavProps) {
         </div>
         <div className="hidden md:flex items-center gap-1">
           <Link href={`/portal/${slug}/leaderboard`} className="px-4 py-2 text-sm font-medium rounded-xl border border-white/20 hover:border-white/40 transition-all text-white/80 hover:text-white">
-            Ranking 🏆
+            Ranking
           </Link>
           <Link href={`/portal/${slug}/campaigns`} className="px-4 py-2 text-sm font-medium rounded-xl border border-white/20 hover:border-white/40 transition-all text-white/80 hover:text-white">
-            Campanhas 💚
+            Campanhas
           </Link>
-          <Link href="/portal/certificate" className="text-sm px-5 py-2.5 rounded-xl bg-gradient-to-r from-var(--pink) to-var(--blue) text-white font-bold shadow-lg shadow-[rgba(29,78,216,0.4)] hover:-translate-y-0.5 transition-all">
-            ✅ Verificar Certificado
+          <Link href="/portal/certificate" className="px-4 py-2 text-sm font-medium rounded-xl border border-white/20 hover:border-white/40 transition-all text-white/80 hover:text-white">
+            Certificado
           </Link>
+          {children}
         </div>
       </div>
     </nav>

--- a/frontend/components/portal/VolunteerModal.tsx
+++ b/frontend/components/portal/VolunteerModal.tsx
@@ -1,0 +1,125 @@
+'use client'
+import { useState } from 'react'
+import { CheckCircle2, Loader2, Users } from 'lucide-react'
+import Modal from '@/components/ui/Modal'
+import { api } from '@/lib/api'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  slug: string
+  orgName?: string
+  campaigns?: Array<{ id: number; nome: string }>
+  defaultCampaignId?: number
+}
+
+export default function VolunteerModal({ open, onClose, slug, orgName, campaigns = [], defaultCampaignId }: Props) {
+  const [campaignId, setCampaignId] = useState<number | ''>(defaultCampaignId ?? '')
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [profissao, setProfissao] = useState('')
+  const [mensagem, setMensagem] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState('')
+
+  const reset = () => {
+    setCampaignId(defaultCampaignId ?? ''); setNome(''); setEmail(''); setTelefone('')
+    setProfissao(''); setMensagem(''); setSubmitting(false); setSuccess(false); setError('')
+  }
+
+  const handleClose = () => { reset(); onClose() }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(''); setSubmitting(true)
+    try {
+      const payload: Record<string, any> = { nome, email }
+      if (telefone) payload.telefone = telefone
+      if (profissao) payload.profissao = profissao
+      if (mensagem) payload.mensagem = mensagem
+      if (campaignId) {
+        payload.campaignId = Number(campaignId)
+        await api.publicExpressInterest(slug, Number(campaignId), payload)
+      } else {
+        await api.publicVolunteerIntent(slug, payload)
+      }
+      setSuccess(true)
+    } catch (err: any) {
+      setError(err?.message || 'Não foi possível registrar sua inscrição.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title={success ? 'Inscrição recebida!' : 'Quero ser voluntário'} size="md">
+      {success ? (
+        <div className="py-4 text-center space-y-4">
+          <div className="w-16 h-16 rounded-full bg-sky-50 border-4 border-sky-100 mx-auto flex items-center justify-center">
+            <CheckCircle2 size={32} className="text-sky-600" />
+          </div>
+          <div>
+            <p className="font-bold text-slate-900 text-lg">Obrigado por se inscrever!</p>
+            <p className="text-slate-600 text-sm mt-1">
+              A coordenação {orgName ? <strong>de {orgName}</strong> : 'da organização'} vai analisar sua candidatura e entrar em contato em <strong>{email}</strong>.
+            </p>
+          </div>
+          <button type="button" onClick={handleClose} className="btn-primary w-full justify-center">Fechar</button>
+        </div>
+      ) : (
+        <form onSubmit={submit} className="space-y-4">
+          <p className="text-sm text-slate-600">
+            <Users size={16} className="inline -mt-0.5 mr-1 text-brand-600" />
+            Preencha o cadastro e a equipe entra em contato para combinar sua participação.
+          </p>
+
+          {campaigns.length > 0 && (
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Campanha de interesse (opcional)</label>
+              <select className="input mt-2" value={campaignId} onChange={e => setCampaignId(e.target.value ? Number(e.target.value) : '')}>
+                <option value="">Qualquer causa / aberto a conhecer</option>
+                {campaigns.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
+              </select>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Nome *</label>
+              <input required className="input mt-2" value={nome} onChange={e => setNome(e.target.value)} placeholder="Seu nome" />
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">E-mail *</label>
+              <input required type="email" className="input mt-2" value={email} onChange={e => setEmail(e.target.value)} placeholder="voce@email.com" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">WhatsApp (opcional)</label>
+              <input className="input mt-2" value={telefone} onChange={e => setTelefone(e.target.value)} placeholder="(11) 99999-9999" />
+            </div>
+            <div>
+              <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Profissão / Área (opcional)</label>
+              <input className="input mt-2" value={profissao} onChange={e => setProfissao(e.target.value)} placeholder="Ex: designer, médico, educador" />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-xs font-bold uppercase tracking-wider text-slate-500">Como você quer contribuir? (opcional)</label>
+            <textarea rows={3} className="input mt-2" value={mensagem} onChange={e => setMensagem(e.target.value)}
+              placeholder="Conte um pouco sobre sua disponibilidade e experiência" />
+          </div>
+
+          {error && <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">{error}</p>}
+
+          <button type="submit" disabled={submitting} className="btn-primary w-full justify-center">
+            {submitting ? <><Loader2 size={16} className="animate-spin" /> Enviando...</> : <><Users size={16} /> Quero ajudar</>}
+          </button>
+        </form>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -156,6 +156,18 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     }),
+  publicVolunteerIntent: (slug: string, data: Record<string, any>) =>
+    publicRequest<any>(`/public/org/${slug}/volunteer-intent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    }),
+  publicDonationIntent: (slug: string, data: Record<string, any>) =>
+    publicRequest<any>(`/public/org/${slug}/donation-intent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    }),
 
   // Campaign interests (admin)
   getCampaignInterests: (params?: Record<string, any>) => request<any>(`/campaign-interests${qs(params)}`),


### PR DESCRIPTION
## Summary

Redesenho do portal público `/portal/[slug]` focado em **conversão** (doação + captação de voluntários). Cada visitante chega numa página com 2 CTAs claros sempre visíveis (Doar / Voluntário), vê impacto social em tempo real, campanhas com urgência e pode doar em 3 cliques.

### Backend (novo)
2 endpoints públicos em `/public/org/:slug`:

| Endpoint | O que faz |
|---|---|
| `POST /donation-intent` | Cria `Donation` com `status=PENDING`, `tipo`, `valor`, dados do doador e campanha opcional. Admin confirma offline (PIX, transferência). |
| `POST /volunteer-intent` | Cria `CampaignInterest` — se o visitante não escolher campanha, anexa à campanha em destaque / mais recente ACTIVE. |

DTOs (`PublicDonationIntentDto`, `PublicVolunteerIntentDto`) com `class-validator`: email válido, nome/email obrigatórios, valor entre 1 e 10M, `tipo` no enum Prisma, `campaignId` opcional.

### Frontend (redesign portal home)

**Novo `app/portal/[slug]/page.tsx`** com:

1. **Sticky nav** com botão âmbar "Doar agora" sempre visível no desktop
2. **Hero** — headline de impacto + 2 CTAs primários (Doar âmbar / Voluntário outline) + trust row (registrado, contato em 24h, 100% vai pra causa)
3. **Card de campanha em destaque** ao lado do hero — progresso %, `Faltam R$ X`, badge URGENTE, badge "X dias restantes" quando perto do prazo, 2 CTAs (Apoiar / Ser voluntário dessa causa)
4. **Impact strip** — 5 números animados com `requestAnimationFrame` (voluntários, campanhas, arrecadado, horas, eventos) + botão Compartilhar (Web Share API com fallback pra copiar link)
5. **Grid de campanhas** — cada card com:
   - top-border colorido por tom (verde se ≥80% meta / vermelho+🔥 se ≤15 dias pro fim / âmbar+⭐ se destaque / navy default)
   - chip de status contextual
   - progress bar + `Faltam R$ X` ou `Meta atingida 🎉`
   - CTAs **Doar** (brand) + **Ajudar** (outline) que abrem modais pré-selecionando a campanha
6. **Agenda de eventos** com badge `● AO VIVO` em eventos ONGOING
7. **Top voluntários** com medalhas
8. **Como funciona** (3 passos ilustrados — registra → confirma → aplicado)
9. **CTA final** em seção navy contrastante
10. **Sticky mobile CTA** no bottom com Doar + Voluntário
11. **Footer** com contatos

**Novos componentes:**
- `components/portal/DonateModal.tsx` — picker de tipo (6 tipos com emoji), presets R$ 25/50/100/250/500 + custom, dropdown opcional de campanha, validação, tela de sucesso
- `components/portal/VolunteerModal.tsx` — dropdown opcional de campanha + profissão + mensagem, tela de sucesso
- `PortalNav` agora aceita `children` pra CTA embutido

**API client:** `publicDonationIntent` + `publicVolunteerIntent` em `lib/api.ts`.

### Paleta & UX
- CTA principal em **amber-400** sobre navy pra contraste forte (conversão)
- Urgência em **vermelho** só onde é real (dias restantes ≤15)
- Navy corporativo mantido no hero, footer e seções secundárias
- Cards com `hover:-translate-y-1` + shadow pra feedback tátil

### Exemplos de fluxo
1. Visitante abre `/portal/voluntarios-unidos` → vê hero com número de voluntários animando
2. Clica "Doar agora" → modal abre com tipo `MONETARY` default + R$ 100 pré-selecionado
3. Preenche nome/email, submete → `POST /public/org/.../donation-intent` → tela "Obrigado! A equipe entra em contato..."
4. No admin, `Doação` aparece como **PENDING** em `/donations` (pronta pra confirmar após PIX recebido)

## Review & Testing Checklist for Human

- [ ] Acessar https://voluntarios-frontend-production.up.railway.app/portal/voluntarios-unidos depois do deploy e conferir o hero novo, botão âmbar "Doar agora", número de voluntários animando, card de campanha em destaque à direita
- [ ] Abrir modal **Doar** (no hero, no card, no CTA final e no sticky mobile) — testar escolher tipo MONETARY, preset R$ 100, nome + email, submeter — deve aparecer tela de sucesso e criar `Donation PENDING` no admin `/donations`
- [ ] Abrir modal **Voluntário** sem selecionar campanha — deve criar `CampaignInterest` vinculado à campanha em destaque (conferir em `/admin` / página de interesses)
- [ ] Testar modal com campanha selecionada + mensagem longa (validação `MaxLength(1000)`)
- [ ] Mobile (≤ 768px): sticky bottom bar com 2 CTAs deve aparecer; seção hero empilha em coluna
- [ ] Segurança: `POST /public/org/<slug>/donation-intent` com `valor: -1` deve retornar **400** (validação `@Min(1)`); idem com email inválido / `tipo` fora do enum
- [ ] Regressão: `/portal/[slug]/campaigns`, `/portal/[slug]/leaderboard`, `/portal/certificate` continuam funcionando

### Notes
- Build frontend + backend passa localmente.
- Endpoints não precisam de migração Prisma — usam tabelas existentes (`Donation` e `CampaignInterest`).
- `DonationStatus.PENDING` e `CampaignInterestStatus.PENDING` já existem no schema — filtros/relatórios do admin já lidam com eles.
- Se quiser um PIX fixo ou link de checkout (Stripe/Mercado Pago) em vez de intenção, é uma evolução natural sobre esse fluxo — hoje o admin concilia manualmente.

Link to Devin session: https://app.devin.ai/sessions/4719aaf8036145abb9f48deb1f2978a0
Requested by: @fredsontocantins