### PR TITLE
feat: volunteer-interests admin page + fix 404s em /campaigns/:id e /events/:id

### DIFF
--- a/backend/src/modules/campaign-interests/campaign-interests.controller.ts
+++ b/backend/src/modules/campaign-interests/campaign-interests.controller.ts
@@ -20,6 +20,12 @@ export class CampaignInterestsController {
     return this.service.list(user.orgId!, { status, campaignId, page, limit })
   }
 
+  @Get('stats')
+  @Roles(UserRole.COORDINATOR, UserRole.ADMIN)
+  async stats(@CurrentUser() user: AuthenticatedUser) {
+    return this.service.stats(user.orgId!)
+  }
+
   @Get(':id')
   @Roles(UserRole.COORDINATOR, UserRole.ADMIN)
   async detail(@CurrentUser() user: AuthenticatedUser, @Param('id', ParseIntPipe) id: number) {

--- a/backend/src/modules/campaign-interests/campaign-interests.service.ts
+++ b/backend/src/modules/campaign-interests/campaign-interests.service.ts
@@ -36,6 +36,20 @@ export class CampaignInterestsService {
     return { data, total, page, totalPages: Math.ceil(total / limit) }
   }
 
+  async stats(orgId: number) {
+    const grouped = await this.prisma.campaignInterest.groupBy({
+      by: ['status'],
+      where: { organizationId: orgId },
+      _count: { _all: true },
+    })
+    const out = { total: 0, PENDING: 0, APPROVED: 0, REJECTED: 0 } as Record<string, number>
+    for (const g of grouped) {
+      out[g.status] = g._count._all
+      out.total += g._count._all
+    }
+    return out
+  }
+
   async getById(orgId: number, id: number) {
     const interest = await this.prisma.campaignInterest.findFirst({
       where: { id, organizationId: orgId },

--- a/frontend/app/campaigns/[id]/page.tsx
+++ b/frontend/app/campaigns/[id]/page.tsx
@@ -1,0 +1,230 @@
+'use client'
+import { useEffect, useState, useCallback } from 'react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  ArrowLeft, Megaphone, Users, Heart, Calendar, DollarSign,
+  Target, CalendarClock, Sparkles, Loader2, ExternalLink,
+} from 'lucide-react'
+import { api } from '@/lib/api'
+import ProgressBar from '@/components/ui/ProgressBar'
+import StatusBadge from '@/components/ui/StatusBadge'
+import { CAMPAIGN_STATUS_STYLE } from '@/lib/chart-colors'
+
+export default function CampaignDetailPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const id = Number(params.id)
+  const [campaign, setCampaign] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const load = useCallback(async () => {
+    if (!id || Number.isNaN(id)) {
+      setError('ID de campanha inválido')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const res = await api.getCampaign(id)
+      setCampaign(res)
+    } catch (e: any) {
+      setError(e?.message || 'Campanha não encontrada')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => { load() }, [load])
+
+  const fmtBRL = (n: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(n || 0)
+  const fmtDate = (v?: string | Date | null) => v ? new Date(v).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' }) : '—'
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-slate-500">
+        <Loader2 className="animate-spin mr-2" size={18} /> Carregando campanha...
+      </div>
+    )
+  }
+
+  if (error || !campaign) {
+    return (
+      <div className="card p-10 text-center space-y-4">
+        <Megaphone size={40} className="mx-auto text-slate-400" />
+        <div>
+          <h1 className="page-title">Campanha não encontrada</h1>
+          <p className="text-slate-500 text-sm mt-1">{error || 'A campanha solicitada não existe ou foi removida.'}</p>
+        </div>
+        <button className="btn-primary" onClick={() => router.push('/campaigns')}>
+          <ArrowLeft size={14} /> Voltar para campanhas
+        </button>
+      </div>
+    )
+  }
+
+  const statusStyle = CAMPAIGN_STATUS_STYLE[campaign.status] || CAMPAIGN_STATUS_STYLE.DRAFT
+  const arrecadado = Number(campaign.arrecadado || 0)
+  const meta = Number(campaign.metaArrecadacao || 0)
+  const progresso = meta > 0 ? Math.min(100, Math.round((arrecadado / meta) * 100)) : 0
+  const restante = Math.max(0, meta - arrecadado)
+  const volunteersCount = campaign.volunteers?.length ?? campaign._count?.volunteers ?? 0
+  const donationsCount = campaign._count?.donations ?? campaign.donations?.length ?? 0
+
+  return (
+    <div className="space-y-6">
+      <Link href="/campaigns" className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700">
+        <ArrowLeft size={14} /> Voltar para campanhas
+      </Link>
+
+      {/* Header card */}
+      <div
+        className="card p-0 overflow-hidden"
+        style={{ borderTop: `4px solid ${statusStyle.bar}` }}
+      >
+        <div className="p-6 space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <StatusBadge status={campaign.status} />
+                {campaign.destaque && (
+                  <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold bg-amber-100 text-amber-800">
+                    <Sparkles size={11} /> Em destaque
+                  </span>
+                )}
+              </div>
+              <h1 className="page-title">{campaign.nome}</h1>
+              {campaign.descricao && <p className="text-slate-600 text-sm max-w-3xl">{campaign.descricao}</p>}
+            </div>
+          </div>
+
+          {/* Stats row */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 pt-2">
+            <div className="bg-green-50 border border-green-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-green-700 text-[11px] font-bold uppercase"><DollarSign size={12} /> Arrecadado</div>
+              <div className="mt-1 text-lg font-bold text-green-900 font-display">{fmtBRL(arrecadado)}</div>
+            </div>
+            <div className="bg-brand-50 border border-brand-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-brand-700 text-[11px] font-bold uppercase"><Target size={12} /> Meta</div>
+              <div className="mt-1 text-lg font-bold text-brand-900 font-display">{fmtBRL(meta)}</div>
+            </div>
+            <div className="bg-amber-50 border border-amber-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-amber-700 text-[11px] font-bold uppercase"><Heart size={12} /> Doações</div>
+              <div className="mt-1 text-lg font-bold text-amber-900 font-display">{donationsCount}</div>
+            </div>
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-slate-700 text-[11px] font-bold uppercase"><Users size={12} /> Voluntários</div>
+              <div className="mt-1 text-lg font-bold text-slate-900 font-display">{volunteersCount}</div>
+            </div>
+          </div>
+
+          {meta > 0 && (
+            <div className="space-y-1.5 pt-2">
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <span>{progresso}% da meta</span>
+                <span>{restante > 0 ? `Faltam ${fmtBRL(restante)}` : 'Meta batida 🎉'}</span>
+              </div>
+              <ProgressBar value={arrecadado} max={meta} size="md" />
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-4 text-xs text-slate-500 pt-2 border-t border-slate-100">
+            <span className="inline-flex items-center gap-1.5"><CalendarClock size={13} /> Início: <strong className="text-slate-700">{fmtDate(campaign.dataInicio)}</strong></span>
+            <span className="inline-flex items-center gap-1.5"><CalendarClock size={13} /> Fim: <strong className="text-slate-700">{fmtDate(campaign.dataFim)}</strong></span>
+            <span className="inline-flex items-center gap-1.5"><Sparkles size={13} /> Criada em <strong className="text-slate-700">{fmtDate(campaign.createdAt)}</strong></span>
+            {campaign.publicavel && (
+              <Link
+                href={`/portal/${campaign.organization?.slug || ''}/campaigns/${campaign.id}`}
+                target="_blank"
+                className="inline-flex items-center gap-1 text-brand-600 font-semibold hover:text-brand-700"
+              >
+                <ExternalLink size={12} /> Ver no portal público
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 2-col: volunteers + recent donations */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <section className="card p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-bold text-slate-800 uppercase tracking-wider flex items-center gap-2">
+              <Users size={14} className="text-brand-600" /> Voluntários alocados ({volunteersCount})
+            </h2>
+          </div>
+          {volunteersCount === 0 ? (
+            <p className="text-sm text-slate-500 py-6 text-center">Ninguém alocado ainda. Use <Link href="/campaigns" className="text-brand-600 font-semibold">"Alocar voluntários"</Link> na lista.</p>
+          ) : (
+            <ul className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+              {campaign.volunteers?.map((cv: any) => (
+                <li key={cv.id} className="flex items-center gap-3 py-2 border-b border-slate-100 last:border-0">
+                  <div className="w-8 h-8 rounded-full bg-brand-100 text-brand-700 flex items-center justify-center text-xs font-bold">
+                    {cv.volunteer?.nome?.[0]?.toUpperCase() || '?'}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-slate-800 truncate">{cv.volunteer?.nome || '—'}</p>
+                    <p className="text-xs text-slate-500 truncate">{cv.volunteer?.email || '—'}</p>
+                  </div>
+                  {cv.volunteer?.status && (
+                    <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 uppercase">
+                      {cv.volunteer.status}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="card p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-bold text-slate-800 uppercase tracking-wider flex items-center gap-2">
+              <Heart size={14} className="text-brand-600" /> Doações recentes
+            </h2>
+          </div>
+          {(!campaign.donations || campaign.donations.length === 0) ? (
+            <p className="text-sm text-slate-500 py-6 text-center">Nenhuma doação registrada ainda.</p>
+          ) : (
+            <ul className="space-y-2 max-h-[360px] overflow-y-auto pr-1">
+              {campaign.donations.map((d: any) => (
+                <li key={d.id} className="flex items-center gap-3 py-2 border-b border-slate-100 last:border-0">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-slate-800 truncate">{d.doadorNome || 'Anônimo'}</p>
+                    <p className="text-xs text-slate-500">{fmtDate(d.createdAt)} · {d.tipo}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-bold text-green-700">{d.valor ? fmtBRL(Number(d.valor)) : '—'}</p>
+                    <p className="text-[10px] font-bold uppercase text-slate-500">{d.status}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      {/* Events */}
+      {campaign.events?.length > 0 && (
+        <section className="card p-5">
+          <h2 className="text-sm font-bold text-slate-800 uppercase tracking-wider flex items-center gap-2 mb-3">
+            <Calendar size={14} className="text-brand-600" /> Eventos vinculados ({campaign.events.length})
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {campaign.events.map((ev: any) => (
+              <Link key={ev.id} href={`/events/${ev.id}`} className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl hover:bg-brand-50 transition">
+                <Calendar size={16} className="text-brand-600" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-800 truncate">{ev.nome}</p>
+                  <p className="text-xs text-slate-500">{fmtDate(ev.dataInicio)} · {ev.local || '—'}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/events/[id]/page.tsx
+++ b/frontend/app/events/[id]/page.tsx
@@ -1,0 +1,160 @@
+'use client'
+import { useEffect, useState, useCallback } from 'react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import {
+  ArrowLeft, Calendar, Users, MapPin, Clock, Loader2,
+  CalendarClock, Building2, Megaphone,
+} from 'lucide-react'
+import { api } from '@/lib/api'
+import StatusBadge from '@/components/ui/StatusBadge'
+import { EVENT_STATUS_STYLE } from '@/lib/chart-colors'
+
+export default function EventDetailPage() {
+  const params = useParams<{ id: string }>()
+  const router = useRouter()
+  const id = Number(params.id)
+  const [event, setEvent] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const load = useCallback(async () => {
+    if (!id || Number.isNaN(id)) {
+      setError('ID de evento inválido')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError('')
+    try {
+      const res = await api.getEvent(id)
+      setEvent(res)
+    } catch (e: any) {
+      setError(e?.message || 'Evento não encontrado')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => { load() }, [load])
+
+  const fmtDate = (v?: string | Date | null) => v ? new Date(v).toLocaleString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—'
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-slate-500">
+        <Loader2 className="animate-spin mr-2" size={18} /> Carregando evento...
+      </div>
+    )
+  }
+
+  if (error || !event) {
+    return (
+      <div className="card p-10 text-center space-y-4">
+        <Calendar size={40} className="mx-auto text-slate-400" />
+        <div>
+          <h1 className="page-title">Evento não encontrado</h1>
+          <p className="text-slate-500 text-sm mt-1">{error || 'O evento solicitado não existe ou foi removido.'}</p>
+        </div>
+        <button className="btn-primary" onClick={() => router.push('/events')}>
+          <ArrowLeft size={14} /> Voltar para eventos
+        </button>
+      </div>
+    )
+  }
+
+  const statusStyle = EVENT_STATUS_STYLE[event.status] || EVENT_STATUS_STYLE.SCHEDULED
+  const registrations = event.registrations || []
+  const capacidade = event.capacidade || 0
+  const inscritos = registrations.length
+  const ocupacaoPct = capacidade > 0 ? Math.min(100, Math.round((inscritos / capacidade) * 100)) : 0
+
+  return (
+    <div className="space-y-6">
+      <Link href="/events" className="inline-flex items-center gap-2 text-sm font-semibold text-brand-600 hover:text-brand-700">
+        <ArrowLeft size={14} /> Voltar para eventos
+      </Link>
+
+      <div
+        className="card p-0 overflow-hidden"
+        style={{ borderTop: `4px solid ${statusStyle.bar}` }}
+      >
+        <div className="p-6 space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <StatusBadge status={event.status} />
+              <h1 className="page-title">{event.nome}</h1>
+              {event.descricao && <p className="text-slate-600 text-sm max-w-3xl">{event.descricao}</p>}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 pt-2">
+            <div className="bg-brand-50 border border-brand-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-brand-700 text-[11px] font-bold uppercase"><CalendarClock size={12} /> Início</div>
+              <div className="mt-1 text-sm font-bold text-brand-900">{fmtDate(event.dataInicio)}</div>
+            </div>
+            <div className="bg-brand-50 border border-brand-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-brand-700 text-[11px] font-bold uppercase"><CalendarClock size={12} /> Fim</div>
+              <div className="mt-1 text-sm font-bold text-brand-900">{fmtDate(event.dataFim)}</div>
+            </div>
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-slate-700 text-[11px] font-bold uppercase"><Users size={12} /> Inscritos</div>
+              <div className="mt-1 text-lg font-bold text-slate-900 font-display">
+                {inscritos}{capacidade ? ` / ${capacidade}` : ''}
+              </div>
+              {capacidade > 0 && (
+                <div className="mt-1 w-full bg-slate-200 rounded-full h-1 overflow-hidden">
+                  <div className="h-1 bg-brand-500 transition-all" style={{ width: `${ocupacaoPct}%` }} />
+                </div>
+              )}
+            </div>
+            <div className="bg-amber-50 border border-amber-100 rounded-xl p-3">
+              <div className="flex items-center gap-2 text-amber-700 text-[11px] font-bold uppercase"><MapPin size={12} /> Local</div>
+              <div className="mt-1 text-sm font-semibold text-amber-900 truncate">{event.local || '—'}</div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-4 text-xs text-slate-500 pt-2 border-t border-slate-100">
+            {event.campaign && (
+              <Link href={`/campaigns/${event.campaign.id}`} className="inline-flex items-center gap-1.5 text-brand-600 font-semibold hover:text-brand-700">
+                <Megaphone size={13} /> Campanha: {event.campaign.nome}
+              </Link>
+            )}
+            {event.tipo && (
+              <span className="inline-flex items-center gap-1.5"><Building2 size={13} /> Tipo: <strong className="text-slate-700">{event.tipo}</strong></span>
+            )}
+            <span className="inline-flex items-center gap-1.5"><Clock size={13} /> Criado em <strong className="text-slate-700">{fmtDate(event.createdAt)}</strong></span>
+          </div>
+        </div>
+      </div>
+
+      <section className="card p-5">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-bold text-slate-800 uppercase tracking-wider flex items-center gap-2">
+            <Users size={14} className="text-brand-600" /> Inscrições ({inscritos})
+          </h2>
+        </div>
+        {inscritos === 0 ? (
+          <p className="text-sm text-slate-500 py-6 text-center">Nenhuma inscrição ainda.</p>
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {registrations.map((r: any) => (
+              <li key={r.id} className="flex items-center gap-3 py-3">
+                <div className="w-9 h-9 rounded-full bg-brand-100 text-brand-700 flex items-center justify-center text-sm font-bold">
+                  {r.volunteer?.nome?.[0]?.toUpperCase() || '?'}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-800 truncate">{r.volunteer?.nome || '—'}</p>
+                  <p className="text-xs text-slate-500 truncate">{r.volunteer?.email || '—'}</p>
+                </div>
+                <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-slate-100 text-slate-600 uppercase">
+                  {r.status || 'INSCRITO'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/app/volunteer-interests/layout.tsx
+++ b/frontend/app/volunteer-interests/layout.tsx
@@ -1,0 +1,4 @@
+import AppShell from "@/components/layout/AppShell"
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <AppShell>{children}</AppShell>
+}

--- a/frontend/app/volunteer-interests/page.tsx
+++ b/frontend/app/volunteer-interests/page.tsx
@@ -1,0 +1,353 @@
+'use client'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { UsersRound, Mail, Phone, Briefcase, Megaphone, Check, X, Loader2, Clock, Filter, MessageSquare } from 'lucide-react'
+import { api } from '@/lib/api'
+import StatusFilterChips from '@/components/ui/StatusFilterChips'
+import Modal from '@/components/ui/Modal'
+import EmptyState from '@/components/ui/EmptyState'
+import { INTEREST_STATUS_STYLE, INTEREST_STATUS_ORDER } from '@/lib/chart-colors'
+
+export default function VolunteerInterestsPage() {
+  const [data, setData] = useState<any>(null)
+  const [stats, setStats] = useState<any>({ total: 0, PENDING: 0, APPROVED: 0, REJECTED: 0 })
+  const [loading, setLoading] = useState(true)
+  const [status, setStatus] = useState('PENDING')
+  const [actionId, setActionId] = useState<number | null>(null)
+  const [rejectTarget, setRejectTarget] = useState<any>(null)
+  const [rejectReason, setRejectReason] = useState('')
+  const [detail, setDetail] = useState<any>(null)
+  const [feedback, setFeedback] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+
+  const loadStats = useCallback(async () => {
+    try { setStats(await api.getCampaignInterestStats()) } catch (e) { console.error(e) }
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params: any = { limit: 50 }
+      if (status) params.status = status
+      const res = await api.getCampaignInterests(params)
+      setData(res)
+    } catch (e) { console.error(e) }
+    finally { setLoading(false) }
+  }, [status])
+
+  useEffect(() => { load() }, [load])
+  useEffect(() => { loadStats() }, [loadStats])
+
+  const fmtDate = (v?: string) => v ? new Date(v).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—'
+
+  async function approve(item: any) {
+    setActionId(item.id)
+    setFeedback(null)
+    try {
+      await api.approveCampaignInterest(item.id)
+      setFeedback({ kind: 'success', text: `${item.nome} aprovado(a) e cadastrado(a) como voluntário ativo.` })
+      await Promise.all([load(), loadStats()])
+    } catch (e: any) {
+      setFeedback({ kind: 'error', text: e?.message || 'Erro ao aprovar' })
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  async function confirmReject() {
+    if (!rejectTarget) return
+    setActionId(rejectTarget.id)
+    setFeedback(null)
+    try {
+      await api.rejectCampaignInterest(rejectTarget.id, rejectReason || 'Rejeitado pela equipe')
+      setFeedback({ kind: 'success', text: `Interesse de ${rejectTarget.nome} rejeitado.` })
+      setRejectTarget(null)
+      setRejectReason('')
+      await Promise.all([load(), loadStats()])
+    } catch (e: any) {
+      setFeedback({ kind: 'error', text: e?.message || 'Erro ao rejeitar' })
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  const statusCounts = useMemo(() => ({
+    PENDING: stats?.PENDING ?? 0,
+    APPROVED: stats?.APPROVED ?? 0,
+    REJECTED: stats?.REJECTED ?? 0,
+  }), [stats])
+
+  const items: any[] = data?.data || []
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="page-title flex items-center gap-3">
+            <UsersRound className="text-brand-600" size={24} />
+            Interesses de Voluntariado
+          </h1>
+          <p className="text-slate-500 text-sm mt-1">
+            Aprove novos voluntários que se inscreveram pelo portal público. Ao aprovar, eles viram voluntários ativos e são alocados à campanha escolhida.
+          </p>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { key: 'total', label: 'Total recebidos', value: stats.total ?? 0, bg: 'bg-slate-50', color: 'text-slate-700', icon: UsersRound },
+          { key: 'PENDING', label: 'Aguardando aprovação', value: stats.PENDING ?? 0, bg: 'bg-amber-50', color: 'text-amber-700', icon: Clock },
+          { key: 'APPROVED', label: 'Aprovados', value: stats.APPROVED ?? 0, bg: 'bg-green-50', color: 'text-green-700', icon: Check },
+          { key: 'REJECTED', label: 'Rejeitados', value: stats.REJECTED ?? 0, bg: 'bg-red-50', color: 'text-red-700', icon: X },
+        ].map(s => (
+          <div key={s.key} className="card p-4 flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-xl ${s.bg} flex items-center justify-center`}>
+              <s.icon size={18} className={s.color} />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-slate-900 font-display leading-none">{s.value}</p>
+              <p className="text-xs text-slate-500 mt-0.5">{s.label}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Filter */}
+      <div className="card p-4 space-y-3">
+        <div className="flex items-center gap-2 text-xs font-bold text-slate-600 uppercase tracking-wider">
+          <Filter size={13} /> Filtrar por status
+        </div>
+        <StatusFilterChips
+          styles={INTEREST_STATUS_STYLE}
+          order={INTEREST_STATUS_ORDER}
+          counts={statusCounts}
+          total={stats.total ?? 0}
+          value={status}
+          onChange={(v) => setStatus(v)}
+        />
+      </div>
+
+      {/* Feedback */}
+      {feedback && (
+        <div className={`p-4 rounded-xl border text-sm font-medium ${
+          feedback.kind === 'success'
+            ? 'bg-green-50 border-green-200 text-green-800'
+            : 'bg-red-50 border-red-200 text-red-800'
+        }`}>
+          {feedback.text}
+        </div>
+      )}
+
+      {/* List */}
+      {loading ? (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="card p-5 animate-pulse">
+              <div className="h-4 bg-slate-100 rounded w-1/3 mb-3" />
+              <div className="h-3 bg-slate-100 rounded w-2/3 mb-2" />
+              <div className="h-3 bg-slate-100 rounded w-1/2" />
+            </div>
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={UsersRound}
+          title={status === 'PENDING' ? 'Nenhum interesse pendente' : 'Nada por aqui'}
+          description={
+            status === 'PENDING'
+              ? 'Quando alguém preencher o formulário de "Quero ser voluntário" no portal público, aparece aqui pra você aprovar ou rejeitar.'
+              : 'Nenhum interesse encontrado com esse filtro.'
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {items.map(item => {
+            const s = INTEREST_STATUS_STYLE[item.status] || INTEREST_STATUS_STYLE.PENDING
+            const isPending = item.status === 'PENDING'
+            const busy = actionId === item.id
+            return (
+              <div
+                key={item.id}
+                className="card p-0 overflow-hidden hover:shadow-lg transition-shadow"
+                style={{ borderTop: `4px solid ${s.bar}` }}
+              >
+                <div className="p-5 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase"
+                          style={{ backgroundColor: s.bg, color: s.text }}
+                        >
+                          {s.label}
+                        </span>
+                        <span className="text-[11px] text-slate-400">#{item.id}</span>
+                      </div>
+                      <h3 className="text-lg font-bold text-slate-900 truncate">{item.nome}</h3>
+                      <p className="text-xs text-slate-500">{fmtDate(item.createdAt)}</p>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-1.5 text-sm text-slate-700">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Mail size={13} className="text-slate-400 flex-shrink-0" />
+                      <a href={`mailto:${item.email}`} className="text-brand-600 hover:underline truncate">{item.email}</a>
+                    </div>
+                    {item.telefone && (
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Phone size={13} className="text-slate-400 flex-shrink-0" />
+                        <a href={`tel:${item.telefone}`} className="hover:underline truncate">{item.telefone}</a>
+                      </div>
+                    )}
+                    {item.profissao && (
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Briefcase size={13} className="text-slate-400 flex-shrink-0" />
+                        <span className="truncate">{item.profissao}</span>
+                      </div>
+                    )}
+                    {item.campaign && (
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Megaphone size={13} className="text-slate-400 flex-shrink-0" />
+                        <span className="text-slate-600 truncate">Campanha: <strong>{item.campaign.nome}</strong></span>
+                      </div>
+                    )}
+                  </div>
+
+                  {item.mensagem && (
+                    <button
+                      type="button"
+                      onClick={() => setDetail(item)}
+                      className="w-full text-left bg-slate-50 hover:bg-slate-100 border border-slate-200 rounded-lg p-2.5 text-xs text-slate-600 flex items-start gap-2 transition"
+                    >
+                      <MessageSquare size={13} className="flex-shrink-0 mt-0.5 text-slate-500" />
+                      <span className="line-clamp-2">{item.mensagem}</span>
+                    </button>
+                  )}
+
+                  <div className="flex items-center gap-2 pt-3 border-t border-slate-100">
+                    <button
+                      type="button"
+                      onClick={() => setDetail(item)}
+                      className="btn-outline text-xs py-1.5 px-3"
+                    >
+                      Ver detalhes
+                    </button>
+                    {isPending && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => approve(item)}
+                          disabled={busy}
+                          className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-60"
+                        >
+                          {busy ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+                          Aprovar
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setRejectTarget(item); setRejectReason('') }}
+                          disabled={busy}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold rounded-lg bg-red-50 text-red-700 hover:bg-red-100 border border-red-200 disabled:opacity-60"
+                        >
+                          <X size={13} /> Rejeitar
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Detail modal */}
+      <Modal open={Boolean(detail)} onClose={() => setDetail(null)} title="Detalhes do interesse">
+        {detail && (
+          <div className="space-y-4 text-sm">
+            <div>
+              <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Nome</p>
+              <p className="font-semibold text-slate-900">{detail.nome}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">E-mail</p>
+                <a href={`mailto:${detail.email}`} className="text-brand-600 hover:underline break-all">{detail.email}</a>
+              </div>
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Telefone</p>
+                <p className="text-slate-800">{detail.telefone || '—'}</p>
+              </div>
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Profissão</p>
+                <p className="text-slate-800">{detail.profissao || '—'}</p>
+              </div>
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Recebido em</p>
+                <p className="text-slate-800">{fmtDate(detail.createdAt)}</p>
+              </div>
+            </div>
+            {detail.campaign && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Campanha desejada</p>
+                <p className="text-slate-800">{detail.campaign.nome}</p>
+              </div>
+            )}
+            {detail.mensagem && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-slate-500 font-bold">Mensagem</p>
+                <p className="text-slate-800 bg-slate-50 border border-slate-200 rounded-lg p-3 whitespace-pre-wrap">{detail.mensagem}</p>
+              </div>
+            )}
+            {detail.status === 'PENDING' && (
+              <div className="flex items-center gap-2 pt-2 border-t border-slate-100">
+                <button
+                  type="button"
+                  onClick={() => { approve(detail); setDetail(null) }}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-bold rounded-lg bg-green-600 text-white hover:bg-green-700"
+                >
+                  <Check size={14} /> Aprovar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setRejectTarget(detail); setRejectReason(''); setDetail(null) }}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-bold rounded-lg bg-red-50 text-red-700 hover:bg-red-100 border border-red-200"
+                >
+                  <X size={14} /> Rejeitar
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
+
+      {/* Reject modal */}
+      <Modal open={Boolean(rejectTarget)} onClose={() => setRejectTarget(null)} title="Rejeitar interesse">
+        {rejectTarget && (
+          <div className="space-y-4">
+            <p className="text-sm text-slate-600">
+              Você está rejeitando o interesse de <strong className="text-slate-900">{rejectTarget.nome}</strong>.
+              Adicione um motivo (opcional) que fica registrado.
+            </p>
+            <textarea
+              className="input min-h-[100px]"
+              placeholder="Motivo (opcional) — ex: campanha encerrada, perfil não se encaixa, etc."
+              value={rejectReason}
+              onChange={e => setRejectReason(e.target.value)}
+            />
+            <div className="flex items-center justify-end gap-2">
+              <button className="btn-outline text-sm" onClick={() => setRejectTarget(null)}>Cancelar</button>
+              <button
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-bold rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+                onClick={confirmReject}
+                disabled={actionId === rejectTarget.id}
+              >
+                {actionId === rejectTarget.id ? <Loader2 size={14} className="animate-spin" /> : <X size={14} />}
+                Confirmar rejeição
+              </button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  )
+}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,43 +1,59 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import {
   LayoutDashboard, Users, Megaphone, Heart, Trophy, FileBarChart,
   Calendar, Settings, LogOut, Leaf, Award, Globe,
-  UsersRound, ChevronRight, Building2, Wallet
+  UsersRound, ChevronRight, Building2, Wallet, Inbox,
 } from 'lucide-react'
 import { useAuthStore } from '@/lib/store'
+import { api } from '@/lib/api'
 import { clsx } from 'clsx'
 
-const gestaoItems = [
-  { href: '/dashboard',     label: 'Dashboard',     icon: LayoutDashboard },
-  { href: '/volunteers',    label: 'Voluntários',   icon: Users },
-  { href: '/campaigns',     label: 'Campanhas',     icon: Megaphone },
-  { href: '/donations',     label: 'Doações',       icon: Heart },
-  { href: '/events',        label: 'Eventos',       icon: Calendar },
-  { href: '/gamification',  label: 'Gamificação',   icon: Trophy },
-  { href: '/reports',       label: 'Relatórios',    icon: FileBarChart },
-  { href: '/finance',        label: 'Financeiro',    icon: Wallet },
+type NavItem = {
+  href: string
+  label: string
+  icon: any
+  badge?: number
+}
+
+const gestaoBase: NavItem[] = [
+  { href: '/dashboard',            label: 'Dashboard',              icon: LayoutDashboard },
+  { href: '/volunteers',           label: 'Voluntários',            icon: Users },
+  { href: '/volunteer-interests',  label: 'Interesses (Portal)',    icon: Inbox },
+  { href: '/campaigns',            label: 'Campanhas',              icon: Megaphone },
+  { href: '/donations',            label: 'Doações',                icon: Heart },
+  { href: '/events',               label: 'Eventos',                icon: Calendar },
+  { href: '/gamification',         label: 'Gamificação',            icon: Trophy },
+  { href: '/reports',              label: 'Relatórios',             icon: FileBarChart },
+  { href: '/finance',              label: 'Financeiro',             icon: Wallet },
 ]
 
-const adminItems = [
+const adminItems: NavItem[] = [
   { href: '/admin/members',      label: 'Equipe Interna', icon: UsersRound },
   { href: '/admin/certificates', label: 'Certificados',   icon: Award },
   { href: '/settings',           label: 'Configurações',  icon: Settings },
 ]
 
-function NavSection({ title, items, pathname }: { title: string; items: typeof gestaoItems; pathname: string }) {
+function NavSection({ title, items, pathname }: { title: string; items: NavItem[]; pathname: string }) {
   return (
     <div className="mb-2">
       <p className="px-3 mb-1 text-[10px] font-bold uppercase tracking-[0.6em] text-[rgba(191,201,247,0.75)]">{title}</p>
-      {items.map(({ href, label, icon: Icon }) => {
+      {items.map(({ href, label, icon: Icon, badge }) => {
         const active = pathname === href || (href !== '/dashboard' && pathname.startsWith(href))
         return (
           <Link key={href} href={href}
             className={clsx('sidebar-link', active && 'active')}>
             <Icon size={16} />
             <span className="flex-1 text-[14px]">{label}</span>
-            {active && <ChevronRight size={13} className="text-white/70" />}
+            {badge && badge > 0 ? (
+              <span className="inline-flex items-center justify-center min-w-[20px] h-[18px] px-1.5 rounded-full bg-amber-400 text-brand-900 text-[10px] font-bold">
+                {badge > 99 ? '99+' : badge}
+              </span>
+            ) : active ? (
+              <ChevronRight size={13} className="text-white/70" />
+            ) : null}
           </Link>
         )
       })}
@@ -50,6 +66,27 @@ export default function Sidebar() {
   const { user, logout } = useAuthStore()
   const slug = user?.organization?.slug || 'voluntarios-unidos'
   const isAdmin = ['ADMIN', 'SUPER_ADMIN'].includes(user?.role || '')
+  const [pendingInterests, setPendingInterests] = useState(0)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+    const fetchPending = async () => {
+      try {
+        const s = await api.getCampaignInterestStats()
+        if (!cancelled) setPendingInterests(s?.PENDING ?? 0)
+      } catch {
+        /* silent — endpoint may 403 for basic roles */
+      }
+    }
+    fetchPending()
+    const intv = setInterval(fetchPending, 60_000)
+    return () => { cancelled = true; clearInterval(intv) }
+  }, [user, pathname])
+
+  const gestaoItems: NavItem[] = gestaoBase.map(i =>
+    i.href === '/volunteer-interests' ? { ...i, badge: pendingInterests } : i,
+  )
 
   return (
     <aside className="fixed left-0 top-0 h-screen z-40 sidebar-shell">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -171,6 +171,7 @@ export const api = {
 
   // Campaign interests (admin)
   getCampaignInterests: (params?: Record<string, any>) => request<any>(`/campaign-interests${qs(params)}`),
+  getCampaignInterestStats: () => request<any>('/campaign-interests/stats'),
   approveCampaignInterest: (id: number) => request<any>(`/campaign-interests/${id}/approve`, { method: 'PUT' }),
   rejectCampaignInterest: (id: number, motivo: string) =>
     request<any>(`/campaign-interests/${id}/reject`, { method: 'PUT', body: JSON.stringify({ motivo }) }),

--- a/frontend/lib/chart-colors.ts
+++ b/frontend/lib/chart-colors.ts
@@ -113,3 +113,11 @@ export const VOLUNTEER_STATUS_STYLE: Record<string, StatusStyle> = {
 }
 
 export const VOLUNTEER_STATUS_ORDER = ['ACTIVE', 'PENDING', 'INACTIVE', 'SUSPENDED'] as const
+
+export const INTEREST_STATUS_STYLE: Record<string, StatusStyle> = {
+  PENDING:  { label: 'Pendente',  bar: '#f59e0b', bg: '#fef3c7', text: '#92400e' },
+  APPROVED: { label: 'Aprovado',  bar: '#16a34a', bg: '#ecfdf5', text: '#166534' },
+  REJECTED: { label: 'Rejeitado', bar: '#dc2626', bg: '#fee2e2', text: '#991b1b' },
+}
+
+export const INTEREST_STATUS_ORDER = ['PENDING', 'APPROVED', 'REJECTED'] as const


### PR DESCRIPTION
## Summary

Entrega duas coisas:

### 1. Tela interna para aprovar/rejeitar interesses de voluntariado do portal público
Quem se inscreve em "Quero ser voluntário" no portal agora cai em uma tela dedicada de aprovação, facilmente acessível pelo menu lateral.

- **Nova página** `/volunteer-interests` com:
  - Chips de filtro por status (`PENDING` / `APPROVED` / `REJECTED`) + "Todas"
  - 4 stat cards no topo (total, pendentes, aprovados, rejeitados)
  - Cards estilo kanban com faixa colorida por status, dados de contato (e-mail/telefone clicáveis), profissão, campanha desejada e mensagem expandível
  - Botões **Aprovar** (verde) e **Rejeitar** (vermelho) em cada card
  - Modal de rejeição com motivo opcional (fica gravado em `mensagem`)
  - Modal de detalhes completo
- **Sidebar** ganha item **"Interesses (Portal)"** com **badge amber** mostrando a contagem de pendentes (poll a cada 60s). Badge some quando zera.
- **Backend** `GET /campaign-interests/stats` — retorna `{ total, PENDING, APPROVED, REJECTED }` agrupado via `groupBy`.

Fluxo completo: visitor no portal → preenche modal → `CampaignInterest` status=PENDING → sidebar badge atualiza → coordenador aprova → vira `Volunteer` ativo alocado à campanha (já existia no service).

### 2. Correção das rotas 404 do dashboard
Lista de campanhas tinha `<Link href="/campaigns/59">` sem página correspondente — 404 garantido. Mesmo problema em `/events/:id`.

- **`/campaigns/[id]`** nova página com:
  - Header com status, destaque, descrição
  - 4 stat cards (arrecadado, meta, doações, voluntários)
  - Progresso até a meta com "faltam R$ X"
  - Voluntários alocados + doações recentes lado a lado
  - Eventos vinculados (linkando para `/events/[id]`)
  - Link para o portal público quando `publicavel=true`
- **`/events/[id]`** nova página com:
  - Header com status, descrição
  - Cards de datas, local, inscritos (barra de ocupação)
  - Lista de inscrições
  - Link cruzado para a campanha
- Nova escala `INTEREST_STATUS_STYLE` em `lib/chart-colors.ts`.

## Review & Testing Checklist for Human

- [ ] Abrir `/volunteer-interests` como admin/coordinator: cards carregam e filtros funcionam
- [ ] Criar um interesse de teste via portal público (`/portal/voluntarios-unidos` → "Quero ser voluntário") e conferir se aparece na lista interna
- [ ] Aprovar: vira voluntário ativo em `/volunteers` e alocado em `/campaigns/:id`; badge da sidebar decrementa
- [ ] Rejeitar com motivo: status atualiza, motivo fica salvo no campo `mensagem`
- [ ] `/campaigns/59` (ou qualquer ID existente) abre a nova página de detalhe sem 404
- [ ] `/events/:id` abre a nova página de detalhe

### Notes

- Endpoints `approve`/`reject` de `campaign-interests` já existiam; só adicionamos `stats`.
- `approve` já cria um `Volunteer` e o aloca na campanha (lógica preexistente em `campaign-interests.service.ts`).
- Badge de pendentes falha silenciosamente se o usuário não tiver permissão (`VOLUNTEER` role) — não quebra a UI.
- Testes locais passando: `npm run build` no frontend (20/20 páginas) e backend (nest build).

Link to Devin session: https://app.devin.ai/sessions/4719aaf8036145abb9f48deb1f2978a0
Requested by: @fredsontocantins